### PR TITLE
chore(repo): configure npm trusted publishing with OIDC

### DIFF
--- a/.changeset/setup-npm-trusted-publishing.md
+++ b/.changeset/setup-npm-trusted-publishing.md
@@ -1,0 +1,9 @@
+---
+'@kidd-cli/core': patch
+'@kidd-cli/cli': patch
+'@kidd-cli/bundler': patch
+'@kidd-cli/config': patch
+'@kidd-cli/utils': patch
+---
+
+Add repository metadata and configure npm trusted publishing with OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -39,4 +44,4 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Programmatic bundler for kidd CLI tools powered by tsdown",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joggrdocs/kidd.git",
+    "directory": "packages/bundler"
+  },
   "files": [
     "dist"
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,11 @@
     "scaffolding"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joggrdocs/kidd.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "kidd": "./dist/index.mjs"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Build-time configuration for kidd CLIs",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joggrdocs/kidd.git",
+    "directory": "packages/config"
+  },
   "files": [
     "dist"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,11 @@
     "zod"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joggrdocs/kidd.git",
+    "directory": "packages/core"
+  },
   "files": [
     "dist"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Shared utilities for the kidd ecosystem",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joggrdocs/kidd.git",
+    "directory": "packages/utils"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

- Replace legacy `NPM_TOKEN` secret with GitHub Actions OIDC authentication for npm publishing
- Add `repository` metadata to all 5 packages for provenance validation
- Add patch changeset across all packages to trigger initial OIDC-based release

## Changes

- **`.github/workflows/release.yml`**: Add `permissions` block (`contents: write`, `pull-requests: write`, `id-token: write`), replace `NODE_AUTH_TOKEN` with `NPM_CONFIG_PROVENANCE: true`
- **`packages/*/package.json`**: Add `repository` field with GitHub URL and package directory to all 5 packages (`core`, `cli`, `bundler`, `config`, `utils`)
- **`.changeset/setup-npm-trusted-publishing.md`**: Patch changeset for all packages

## Manual steps required after merge

1. Publish placeholder packages to npm (or do initial publish) for all `@kidd-cli/*` packages
2. Configure trusted publishers on npmjs.com for each package (org: `joggrdocs`, repo: `kidd`, workflow: `release.yml`)
3. Delete the `NPM_TOKEN` secret from GitHub repo settings

## Testing

- [ ] Verify CI passes
- [ ] Confirm trusted publishers are configured on npmjs.com before merging
- [ ] Validate first OIDC-based publish succeeds after merge