### PR TITLE
refactor(packages/core,packages/cli): fix coding standards violations

### DIFF
--- a/.changeset/fix-standards-violations.md
+++ b/.changeset/fix-standards-violations.md
@@ -1,0 +1,8 @@
+---
+'@kidd-cli/core': patch
+'@kidd-cli/cli': patch
+---
+
+Fix coding standards violations across packages
+
+Replace `as` type assertions with type annotations, type guards, and documented exceptions. Replace `try/catch` blocks with `attempt`/`attemptAsync` from es-toolkit. Replace multi-branch `if/else` chains with `ts-pattern` `match` expressions. Rename `redactPaths` constant to `REDACT_PATHS`. Document intentional mutation and `throw` exceptions with inline comments.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from '@kidd-cli/config/loader'
 import { command } from '@kidd-cli/core'
 import type { Command, Context } from '@kidd-cli/core'
+import { match } from '@kidd-cli/utils/fp'
 import { readManifest } from '@kidd-cli/utils/manifest'
 import pc from 'picocolors'
 import { z } from 'zod'
@@ -216,19 +217,11 @@ function formatResultLine(
  * @returns A colored string representation of the status.
  */
 function formatDisplayStatus(status: CheckStatus | 'fix'): string {
-  if (status === 'pass') {
-    return pc.green('pass')
-  }
-
-  if (status === 'warn') {
-    return pc.yellow('warn')
-  }
-
-  if (status === 'fix') {
-    return pc.blue('fix ')
-  }
-
-  return pc.red('fail')
+  return match(status)
+    .with('pass', () => pc.green('pass'))
+    .with('warn', () => pc.yellow('warn'))
+    .with('fix', () => pc.blue('fix '))
+    .otherwise(() => pc.red('fail'))
 }
 
 /**

--- a/packages/core/src/autoloader.ts
+++ b/packages/core/src/autoloader.ts
@@ -40,7 +40,8 @@ export async function autoload(options?: AutoloadOptions): Promise<CommandMap> {
   const allResults = [...fileResults, ...dirResults]
   const validPairs = allResults.filter((pair): pair is [string, Command] => pair !== undefined)
 
-  return Object.fromEntries(validPairs) as CommandMap
+  const commandMap: CommandMap = Object.fromEntries(validPairs)
+  return commandMap
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +122,8 @@ async function buildSubCommands(dir: string, entries: Dirent[]): Promise<Command
   const allResults = [...fileResults, ...dirResults]
   const validPairs = allResults.filter((pair): pair is [string, Command] => pair !== undefined)
 
-  return Object.fromEntries(validPairs) as CommandMap
+  const commandMap: CommandMap = Object.fromEntries(validPairs)
+  return commandMap
 }
 
 /**
@@ -170,7 +172,10 @@ function isCommandExport(mod: unknown): mod is { default: Command } {
   if (typeof mod !== 'object' || mod === null) {
     return false
   }
-  const def = (mod as Record<string, unknown>)['default']
+  if (!('default' in mod)) {
+    return false
+  }
+  const def: unknown = mod.default
   if (!isPlainObject(def)) {
     return false
   }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 
 import { loadConfig } from '@kidd-cli/config/loader'
-import { attemptAsync, isPlainObject, isString } from '@kidd-cli/utils/fp'
+import { P, attemptAsync, isPlainObject, isString, match } from '@kidd-cli/utils/fp'
 import yargs from 'yargs'
 import type { z } from 'zod'
 
@@ -53,9 +53,9 @@ export async function cli<TSchema extends z.ZodType = z.ZodType>(
       program.demandCommand(1, 'You must specify a command.')
     }
 
-    const argv = await program.parseAsync()
+    const argv: Record<string, unknown> = await program.parseAsync()
 
-    applyCwd(argv as Record<string, unknown>)
+    applyCwd(argv)
 
     if (!resolved.ref) {
       return undefined
@@ -77,7 +77,7 @@ export async function cli<TSchema extends z.ZodType = z.ZodType>(
       commandPath: resolved.ref.commandPath,
       handler: resolved.ref.handler,
       middleware: resolved.ref.middleware,
-      rawArgs: argv as Record<string, unknown>,
+      rawArgs: argv,
     })
 
     return executeError
@@ -121,7 +121,7 @@ async function resolveCommands(
     return commands
   }
   if (isPlainObject(commands)) {
-    return commands as CommandMap
+    return commands
   }
   return resolveCommandsFromConfig()
 }
@@ -172,14 +172,11 @@ function applyCwd(argv: Record<string, unknown>): void {
  * @param logger - Logger with an error method for output.
  */
 function exitOnError(error: unknown, logger: { error(msg: string): void }): void {
-  if (isContextError(error)) {
-    logger.error(error.message)
-    process.exit(error.exitCode)
-  } else if (error instanceof Error) {
-    logger.error(error.message)
-    process.exit(DEFAULT_EXIT_CODE)
-  } else {
-    logger.error(String(error))
-    process.exit(DEFAULT_EXIT_CODE)
-  }
+  const info = match(error)
+    .when(isContextError, (e) => ({ exitCode: e.exitCode, message: e.message }))
+    .with(P.instanceOf(Error), (e) => ({ exitCode: DEFAULT_EXIT_CODE, message: e.message }))
+    .otherwise((e) => ({ exitCode: DEFAULT_EXIT_CODE, message: String(e) }))
+
+  logger.error(info.message)
+  process.exit(info.exitCode)
 }

--- a/packages/core/src/context/create-context.ts
+++ b/packages/core/src/context/create-context.ts
@@ -56,6 +56,8 @@ export function createContext<TArgs extends AnyRecord, TConfig extends AnyRecord
     args: options.args as Context<TArgs, TConfig>['args'],
     config: options.config as Context<TArgs, TConfig>['config'],
     fail(message: string, failOptions?: { code?: string; exitCode?: number }): never {
+      // Accepted exception: ctx.fail() is typed `never` and caught by the CLI boundary.
+      // This is the framework's halt mechanism — the runner catches the thrown ContextError.
       throw createContextError(message, failOptions)
     },
     logger: ctxLogger,

--- a/packages/core/src/context/error.ts
+++ b/packages/core/src/context/error.ts
@@ -52,8 +52,12 @@ export function createContextError(
   options?: { code?: string; exitCode?: number }
 ): ContextError {
   const data = createContextErrorData(message, options)
+  // Accepted exception: Error construction requires `new Error()` then property decoration.
+  // The `as` cast and Object.defineProperty mutations are the only way to produce a
+  // Tagged Error subtype without using a class.
   const error = new Error(data.message) as ContextError
   error.name = 'ContextError'
+  // Intentional mutation: decorating an Error object with immutable properties.
   Object.defineProperty(error, TAG, { enumerable: false, value: 'ContextError', writable: false })
   Object.defineProperty(error, 'code', { enumerable: true, value: data.code, writable: false })
   Object.defineProperty(error, 'exitCode', {

--- a/packages/core/src/context/prompts.ts
+++ b/packages/core/src/context/prompts.ts
@@ -54,6 +54,8 @@ export function createContextPrompts(): Prompts {
 function unwrapCancelSignal<Type>(result: Type | symbol): Type {
   if (clack.isCancel(result)) {
     clack.cancel('Operation cancelled.')
+    // Accepted exception: prompt cancellation must propagate as an unwind.
+    // The runner catches the thrown ContextError at the CLI boundary.
     throw createContextError('Prompt cancelled by user', {
       code: 'PROMPT_CANCELLED',
       exitCode: DEFAULT_EXIT_CODE,

--- a/packages/core/src/context/redact.ts
+++ b/packages/core/src/context/redact.ts
@@ -30,7 +30,7 @@ const SPECIFIC_PATHS: readonly string[] = [
   'env.LINEAR_API_KEY',
 ]
 
-const redactPaths = pinoRedact({
+const REDACT_PATHS = pinoRedact({
   censor: resolveCensor,
   paths: [...SPECIFIC_PATHS],
   serialize: false,
@@ -64,7 +64,10 @@ function resolveCensor(value: unknown): unknown {
  * @returns A deep clone with sensitive values replaced.
  */
 export function redactObject<TObj extends object>(obj: TObj): TObj {
-  const pathRedacted = redactPaths(obj)
+  // Accepted exception: pinoRedact returns unknown and the recursive walk
+  // Requires Record<string, unknown>. TObj is preserved for the caller.
+  // eslint-disable-next-line new-cap -- REDACT_PATHS is a function from pinoRedact, not a constructor
+  const pathRedacted = REDACT_PATHS(obj)
   return redactSensitiveKeys(pathRedacted as Record<string, unknown>) as TObj
 }
 
@@ -101,8 +104,8 @@ function redactEntry(key: string, value: unknown): [string, unknown] {
     return [key, value.map(redactArrayItem)]
   }
 
-  if (value && typeof value === 'object') {
-    return [key, redactSensitiveKeys(value as Record<string, unknown>)]
+  if (isNonNullObject(value)) {
+    return [key, redactSensitiveKeys(value)]
   }
 
   return [key, value]
@@ -116,8 +119,19 @@ function redactEntry(key: string, value: unknown): [string, unknown] {
  * @returns The element with sensitive keys redacted, or the original primitive.
  */
 function redactArrayItem(item: unknown): unknown {
-  if (item && typeof item === 'object') {
-    return redactSensitiveKeys(item as Record<string, unknown>)
+  if (isNonNullObject(item)) {
+    return redactSensitiveKeys(item)
   }
   return item
+}
+
+/**
+ * Type guard that narrows an unknown value to a string-keyed record.
+ *
+ * @private
+ * @param value - The value to check.
+ * @returns True when the value is a non-null object.
+ */
+function isNonNullObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/packages/core/src/lib/config/parse.ts
+++ b/packages/core/src/lib/config/parse.ts
@@ -115,6 +115,8 @@ function parseJsoncContent(
   content: string,
   filePath: string
 ): ConfigOperationResult<unknown> {
+  // Intentional mutation: jsonc-parser API requires a mutable errors array.
+  // There is no immutable alternative — the parser populates it during parsing.
   const errors: ParseError[] = []
   const result = parseJsonc(content, errors, {
     allowEmptyContent: false,

--- a/packages/core/src/lib/project/root.ts
+++ b/packages/core/src/lib/project/root.ts
@@ -27,13 +27,11 @@ export function findProjectRoot(startDir: string = process.cwd()): ProjectRoot |
     const nextVisited = new Set([...visited, currentDir])
 
     const gitPath = join(currentDir, '.git')
-    try {
-      const result = checkGitPath(gitPath, currentDir)
-      if (result) {
-        return result
-      }
-    } catch {
-      // Race condition: file may have been deleted between existsSync and statSync
+    // Race condition: file may have been deleted between existsSync and statSync
+    const [checkError, result] = attempt(() => checkGitPath(gitPath, currentDir))
+
+    if (!checkError && result) {
+      return result
     }
 
     const parent = dirname(currentDir)

--- a/packages/core/src/middleware/auth/credential.ts
+++ b/packages/core/src/middleware/auth/credential.ts
@@ -1,3 +1,5 @@
+import { attemptAsync } from '@kidd-cli/utils/fp'
+
 import type { BearerCredential } from './types.js'
 
 /**
@@ -49,14 +51,18 @@ export async function postFormEncoded(
   params: URLSearchParams,
   signal?: AbortSignal
 ): Promise<Response | null> {
-  try {
-    return await fetch(url, {
+  const [fetchError, response] = await attemptAsync(() =>
+    fetch(url, {
       body: params.toString(),
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       method: 'POST',
       signal,
     })
-  } catch {
+  )
+
+  if (fetchError) {
     return null
   }
+
+  return response
 }

--- a/packages/core/src/middleware/auth/oauth-server.ts
+++ b/packages/core/src/middleware/auth/oauth-server.ts
@@ -13,7 +13,7 @@ import type { IncomingMessage, Server, ServerResponse } from 'node:http'
 import type { Socket } from 'node:net'
 import { platform } from 'node:os'
 
-import { match } from 'ts-pattern'
+import { attempt, match } from '@kidd-cli/utils/fp'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -170,21 +170,21 @@ export function sendSuccessPage(res: ServerResponse): void {
  * @returns True when the URL uses HTTPS or HTTP on a loopback address.
  */
 export function isSecureAuthUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url)
+  const [error, parsed] = attempt(() => new URL(url))
 
-    if (parsed.protocol === 'https:') {
-      return true
-    }
-
-    if (parsed.protocol !== 'http:') {
-      return false
-    }
-
-    return isLoopbackHost(parsed.hostname)
-  } catch {
+  if (error || !parsed) {
     return false
   }
+
+  if (parsed.protocol === 'https:') {
+    return true
+  }
+
+  if (parsed.protocol !== 'http:') {
+    return false
+  }
+
+  return isLoopbackHost(parsed.hostname)
 }
 
 /**
@@ -276,12 +276,13 @@ export function startLocalServer(options: {
  * @returns True when the URL uses http: or https: protocol.
  */
 function isHttpUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url)
-    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
-  } catch {
+  const [error, parsed] = attempt(() => new URL(url))
+
+  if (error || !parsed) {
     return false
   }
+
+  return parsed.protocol === 'https:' || parsed.protocol === 'http:'
 }
 
 /**

--- a/packages/core/src/middleware/auth/strategies/device-code.ts
+++ b/packages/core/src/middleware/auth/strategies/device-code.ts
@@ -8,7 +8,7 @@
  * @module
  */
 
-import { match } from 'ts-pattern'
+import { attemptAsync, match } from '@kidd-cli/utils/fp'
 
 import type { Prompts } from '@/context/types.js'
 
@@ -136,13 +136,13 @@ async function requestDeviceAuth(options: {
     return null
   }
 
-  try {
-    const data: unknown = await response.json()
+  const [parseError, data] = await attemptAsync((): Promise<unknown> => response.json())
 
-    return parseDeviceAuthResponse(data)
-  } catch {
+  if (parseError) {
     return null
   }
+
+  return parseDeviceAuthResponse(data)
 }
 
 /**
@@ -197,14 +197,13 @@ async function displayUserCode(
   verificationUri: string,
   userCode: string
 ): Promise<void> {
-  try {
-    await prompts.text({
+  // User cancellation is non-fatal — polling will handle timeout
+  await attemptAsync(() =>
+    prompts.text({
       defaultValue: '',
       message: `Open ${verificationUri} and enter code: ${userCode} (press Enter to continue)`,
     })
-  } catch {
-    // User cancelled -- continue anyway, polling will handle timeout
-  }
+  )
 }
 
 /**
@@ -346,34 +345,34 @@ async function requestToken(options: {
     return { status: 'error' }
   }
 
-  try {
-    const data: unknown = await response.json()
+  const [parseError, data] = await attemptAsync((): Promise<unknown> => response.json())
 
-    if (typeof data !== 'object' || data === null) {
-      return { status: 'error' }
-    }
-
-    const record = data as Record<string, unknown>
-
-    if (response.ok && typeof record.access_token === 'string' && record.access_token !== '') {
-      if (typeof record.token_type === 'string' && record.token_type.toLowerCase() !== 'bearer') {
-        return { status: 'error' }
-      }
-
-      return { credential: createBearerCredential(record.access_token), status: 'success' }
-    }
-
-    if (typeof record.error !== 'string') {
-      return { status: 'error' }
-    }
-
-    return match(record.error)
-      .with('authorization_pending', (): TokenRequestResult => ({ status: 'pending' }))
-      .with('slow_down', (): TokenRequestResult => ({ status: 'slow_down' }))
-      .with('expired_token', (): TokenRequestResult => ({ status: 'expired' }))
-      .with('access_denied', (): TokenRequestResult => ({ status: 'denied' }))
-      .otherwise((): TokenRequestResult => ({ status: 'error' }))
-  } catch {
+  if (parseError) {
     return { status: 'error' }
   }
+
+  if (typeof data !== 'object' || data === null) {
+    return { status: 'error' }
+  }
+
+  const record = data as Record<string, unknown>
+
+  if (response.ok && typeof record.access_token === 'string' && record.access_token !== '') {
+    if (typeof record.token_type === 'string' && record.token_type.toLowerCase() !== 'bearer') {
+      return { status: 'error' }
+    }
+
+    return { credential: createBearerCredential(record.access_token), status: 'success' }
+  }
+
+  if (typeof record.error !== 'string') {
+    return { status: 'error' }
+  }
+
+  return match(record.error)
+    .with('authorization_pending', (): TokenRequestResult => ({ status: 'pending' }))
+    .with('slow_down', (): TokenRequestResult => ({ status: 'slow_down' }))
+    .with('expired_token', (): TokenRequestResult => ({ status: 'expired' }))
+    .with('access_denied', (): TokenRequestResult => ({ status: 'denied' }))
+    .otherwise((): TokenRequestResult => ({ status: 'error' }))
 }

--- a/packages/core/src/middleware/auth/strategies/oauth.ts
+++ b/packages/core/src/middleware/auth/strategies/oauth.ts
@@ -11,6 +11,8 @@
 import { createHash, randomBytes } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
+import { attemptAsync } from '@kidd-cli/utils/fp'
+
 import { createBearerCredential, postFormEncoded } from '../credential.js'
 import {
   createDeferred,
@@ -300,25 +302,25 @@ async function exchangeCodeForToken(options: {
     return null
   }
 
-  try {
-    const data: unknown = await response.json()
+  const [parseError, data] = await attemptAsync((): Promise<unknown> => response.json())
 
-    if (typeof data !== 'object' || data === null) {
-      return null
-    }
-
-    const record = data as Record<string, unknown>
-
-    if (typeof record.access_token !== 'string' || record.access_token === '') {
-      return null
-    }
-
-    if (typeof record.token_type === 'string' && record.token_type.toLowerCase() !== 'bearer') {
-      return null
-    }
-
-    return createBearerCredential(record.access_token)
-  } catch {
+  if (parseError) {
     return null
   }
+
+  if (typeof data !== 'object' || data === null) {
+    return null
+  }
+
+  const record = data as Record<string, unknown>
+
+  if (typeof record.access_token !== 'string' || record.access_token === '') {
+    return null
+  }
+
+  if (typeof record.token_type === 'string' && record.token_type.toLowerCase() !== 'bearer') {
+    return null
+  }
+
+  return createBearerCredential(record.access_token)
 }

--- a/packages/core/src/middleware/auth/strategies/token.ts
+++ b/packages/core/src/middleware/auth/strategies/token.ts
@@ -1,3 +1,5 @@
+import { attemptAsync } from '@kidd-cli/utils/fp'
+
 import type { Prompts } from '@/context/types.js'
 
 import { createBearerCredential, isValidToken } from '../credential.js'
@@ -18,15 +20,17 @@ export async function resolveFromToken(options: {
   readonly message: string
   readonly prompts: Prompts
 }): Promise<AuthCredential | null> {
-  try {
-    const token = await options.prompts.password({ message: options.message })
+  const [promptError, token] = await attemptAsync(() =>
+    options.prompts.password({ message: options.message })
+  )
 
-    if (!isValidToken(token)) {
-      return null
-    }
-
-    return createBearerCredential(token)
-  } catch {
+  if (promptError) {
     return null
   }
+
+  if (!isValidToken(token)) {
+    return null
+  }
+
+  return createBearerCredential(token)
 }

--- a/packages/core/src/middleware/http/create-http-client.ts
+++ b/packages/core/src/middleware/http/create-http-client.ts
@@ -241,6 +241,9 @@ async function executeRequest<TResponse>(
  * @returns The parsed body or null.
  */
 async function parseResponseBody<TResponse>(response: Response): Promise<TResponse> {
+  // Accepted exception: generic TResponse cannot be inferred from response.json().
+  // The `as` casts bridge the generic HTTP client boundary. Callers provide TResponse
+  // At the call site and accept the runtime type risk.
   const [error, data] = await attemptAsync(() => response.json() as Promise<TResponse>)
 
   if (error) {

--- a/packages/core/src/runtime/args/register.ts
+++ b/packages/core/src/runtime/args/register.ts
@@ -23,8 +23,7 @@ export function registerCommandArgs(builder: Argv, args: Command['args']): void 
       builder.option(key, opt)
     }
   } else {
-    const argsDef = args as Record<string, YargsArgDef>
-    for (const [key, def] of Object.entries(argsDef)) {
+    for (const [key, def] of Object.entries(args)) {
       builder.option(key, yargsArgDefToOption(def))
     }
   }
@@ -44,7 +43,7 @@ export function registerCommandArgs(builder: Argv, args: Command['args']): void 
 function yargsArgDefToOption(def: YargsArgDef): YargsOptions {
   return {
     alias: def.alias,
-    choices: def.choices as string[],
+    choices: def.choices,
     default: def.default,
     demandOption: def.required ?? false,
     describe: def.description,

--- a/packages/core/src/runtime/register.ts
+++ b/packages/core/src/runtime/register.ts
@@ -28,12 +28,14 @@ export function isCommand(value: unknown): value is Command {
  */
 export function registerCommands(options: RegisterCommandsOptions): void {
   const { instance, commands, resolved, parentPath } = options
-  const commandEntries = Object.entries(commands).filter(([, entry]) => isCommand(entry))
+  const commandEntries = Object.entries(commands).filter(
+    (pair): pair is [string, Command] => isCommand(pair[1])
+  )
 
   for (const [name, entry] of commandEntries) {
     registerResolvedCommand({
       builder: instance,
-      cmd: entry as Command,
+      cmd: entry,
       instance,
       name,
       parentPath,
@@ -85,12 +87,14 @@ function registerResolvedCommand(options: RegisterResolvedCommandOptions): void 
       registerCommandArgs(builder, cmd.args)
 
       if (cmd.commands) {
-        const subCommands = Object.entries(cmd.commands).filter(([, entry]) => isCommand(entry))
+        const subCommands = Object.entries(cmd.commands).filter(
+          (pair): pair is [string, Command] => isCommand(pair[1])
+        )
 
         for (const [subName, subEntry] of subCommands) {
           registerResolvedCommand({
             builder,
-            cmd: subEntry as Command,
+            cmd: subEntry,
             instance: builder,
             name: subName,
             parentPath: [...parentPath, name],
@@ -108,6 +112,9 @@ function registerResolvedCommand(options: RegisterResolvedCommandOptions): void 
       return builder
     },
     () => {
+      // Intentional mutation: yargs callback model requires mutable ref capture.
+      // The `as` casts are accepted exceptions — generic handler/middleware types
+      // Cannot be narrowed further inside the yargs callback boundary.
       resolved.ref = {
         args: cmd.args,
         commandPath: [...parentPath, name],

--- a/packages/core/src/runtime/runtime.ts
+++ b/packages/core/src/runtime/runtime.ts
@@ -26,7 +26,8 @@ export async function createRuntime<TSchema extends z.ZodType>(
 ): AsyncResult<Runtime, Error> {
   const config = await resolveConfig(options.config, options.name)
 
-  const runner = createRunner((options.middleware ?? []) as Middleware[])
+  const middleware: Middleware[] = options.middleware ?? []
+  const runner = createRunner(middleware)
 
   const runtime: Runtime = {
     async execute(command): AsyncResult<void, Error> {
@@ -40,7 +41,7 @@ export async function createRuntime<TSchema extends z.ZodType>(
         args: validatedArgs,
         config,
         meta: {
-          command: command.commandPath as string[],
+          command: [...command.commandPath],
           name: options.name,
           version: options.version,
         },
@@ -48,6 +49,8 @@ export async function createRuntime<TSchema extends z.ZodType>(
 
       const finalHandler = command.handler ?? (async () => {})
 
+      // Accepted exception: generic context assembly requires type assertions.
+      // The generics are validated at the createContext call site.
       const [execError] = await attemptAsync(() =>
         runner.execute({
           ctx: ctx as Context,
@@ -96,5 +99,7 @@ async function resolveConfig<TSchema extends z.ZodType>(
   if (configError || !configResult) {
     return {}
   }
+  // Accepted exception: configResult.config is generic TOutput from zod schema.
+  // The cast bridges the generic boundary to the internal Record type.
   return configResult.config as Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

Fix six open standards violation issues across `packages/core` and `packages/cli`. Removes unnecessary `as` type assertions, replaces `try/catch` with `attempt`/`attemptAsync`, introduces `ts-pattern` `match` for multi-branch conditionals, and documents intentional boundary exceptions.

## Changes

**Issue #12 — Replace `as` type assertions:**
- `cli.ts`: Add explicit type annotation on `argv`, remove redundant `as Record<string, unknown>` and `as CommandMap`
- `autoloader.ts`: Replace `as CommandMap` with typed variable, use `'default' in mod` guard instead of `as Record<string, unknown>`
- `register.ts`: Use tuple type predicate in `filter()` to eliminate `as Command` casts
- `runtime.ts`: Replace `as Middleware[]` with typed variable, replace `as string[]` with spread, document accepted exceptions
- `args/register.ts`: Remove redundant `as Record<string, YargsArgDef>` (narrowed by `isZodSchema` guard) and `as string[]`
- `create-http-client.ts`, `redact.ts`, `error.ts`: Document accepted boundary exceptions with inline comments

**Issue #15 — Replace `try/catch` with `attemptAsync`:**
- `oauth.ts`, `device-code.ts`, `token.ts`: Replace JSON parse and prompt try/catch with `attemptAsync`
- `oauth-server.ts`: Replace URL parse try/catch with `attempt`
- `credential.ts`: Replace fetch try/catch with `attemptAsync`
- `root.ts`: Replace statSync try/catch with `attempt`

**Issue #18 — Document `throw` exceptions:**
- `create-context.ts`: Document `ctx.fail()` throw as framework halt mechanism
- `prompts.ts`: Document prompt cancellation throw as CLI boundary unwind

**Issue #20 — Fix naming violations:**
- `redact.ts`: Rename `redactPaths` to `REDACT_PATHS`

**Issue #21 — Document intentional mutations:**
- `register.ts`: Document yargs callback mutable ref capture
- `parse.ts`: Document jsonc-parser mutable errors array
- `error.ts`: Document Error object property decoration

**Issue #33 — Use `ts-pattern` for multi-branch conditionals:**
- `cli.ts`: Replace `exitOnError` if/else chain with `match`/`P.instanceOf`
- `doctor.ts`: Replace `formatDisplayStatus` if/else chain with `match`

## Testing

- `pnpm typecheck` — passes (0 errors)
- `pnpm lint` — 0 errors, 0 new warnings
- `pnpm test` — 566 tests pass (456 core, 110 cli)

## Related Issues

Closes #12, Closes #15, Closes #18, Closes #20, Closes #21, Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling with better null checks and defensive property access across authentication flows
  * Enhanced type safety in command registration and execution paths

* **Refactor**
  * Standardized conditional logic using consistent functional patterns
  * Consolidated error handling across multiple code paths
  * Added clarifying comments for intentional operations and error propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->