### PR TITLE
fix(packages/core,packages/bundler): exclude .d.ts files from command autoloader

### DIFF
--- a/.changeset/fix-dts-autoloader.md
+++ b/.changeset/fix-dts-autoloader.md
@@ -1,0 +1,13 @@
+---
+'@kidd-cli/core': patch
+'@kidd-cli/bundler': patch
+---
+
+fix(packages/core,packages/bundler): exclude .d.ts files from command autoloader
+
+The `isCommandFile` and `findIndexEntry` functions used `extname()` to check
+file extensions, but `extname('build.d.ts')` returns `'.ts'`, causing `.d.ts`
+declaration files to pass the filter. When `@kidd-cli/cli` is installed under
+`node_modules` and its `dist/commands/` directory contains `.d.ts` files, the
+runtime autoloader attempts to `import()` them, triggering a Node 24 type
+stripping error for files under `node_modules`.

--- a/packages/bundler/src/autoloader/scan-commands.test.ts
+++ b/packages/bundler/src/autoloader/scan-commands.test.ts
@@ -153,6 +153,19 @@ describe('scan commands directory', () => {
     expect(cloud?.files).toHaveLength(2)
   })
 
+  it('should skip .d.ts declaration files', async () => {
+    vi.mocked(readdir).mockResolvedValueOnce([
+      makeDirent('build.d.ts', true),
+      makeDirent('init.d.ts', true),
+      makeDirent('status.ts', true),
+    ] as Dirent[])
+
+    const result = await scanCommandsDir('/project/commands')
+
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.name).toBe('status')
+  })
+
   it('should handle .mjs extension', async () => {
     vi.mocked(readdir).mockResolvedValueOnce([makeDirent('status.mjs', true)] as Dirent[])
 

--- a/packages/bundler/src/autoloader/scan-commands.ts
+++ b/packages/bundler/src/autoloader/scan-commands.ts
@@ -83,6 +83,7 @@ function findIndexEntry(entries: readonly Dirent[]): Dirent | undefined {
   return entries.find(
     (entry) =>
       entry.isFile() &&
+      !entry.name.endsWith('.d.ts') &&
       VALID_EXTENSIONS.has(extname(entry.name)) &&
       basename(entry.name, extname(entry.name)) === INDEX_NAME
   )
@@ -100,6 +101,9 @@ function isCommandFile(entry: Dirent): boolean {
     return false
   }
   if (entry.name.startsWith('_') || entry.name.startsWith('.')) {
+    return false
+  }
+  if (entry.name.endsWith('.d.ts')) {
     return false
   }
   if (!VALID_EXTENSIONS.has(extname(entry.name))) {

--- a/packages/core/src/autoload.test.ts
+++ b/packages/core/src/autoload.test.ts
@@ -212,6 +212,23 @@ describe('autoload()', () => {
     expect(result['deploy'].description).toBe('Deploy app')
   })
 
+  it('should ignore .d.ts declaration files', async () => {
+    mockedReaddir.mockResolvedValue([
+      makeDirent('build.d.ts', true),
+      makeDirent('init.d.ts', true),
+      makeDirent('init.ts', true),
+    ] as unknown as Dirent[])
+
+    vi.doMock('/tmp/commands/init.ts', () => ({
+      default: withTag({ description: 'Init' }, 'Command'),
+    }))
+
+    const result = await autoload({ dir: '/tmp/commands' })
+
+    expect(Object.keys(result)).toStrictEqual(['init'])
+    expect(hasTag(result['init'], 'Command')).toBeTruthy()
+  })
+
   it('should ignore non-ts/js files', async () => {
     mockedReaddir.mockResolvedValue([
       makeDirent('readme.md', true),

--- a/packages/core/src/autoload.ts
+++ b/packages/core/src/autoload.ts
@@ -120,6 +120,7 @@ function findIndexInEntries(entries: Dirent[]): Dirent | undefined {
   return entries.find(
     (entry) =>
       entry.isFile() &&
+      !entry.name.endsWith('.d.ts') &&
       VALID_EXTENSIONS.has(extname(entry.name)) &&
       basename(entry.name, extname(entry.name)) === INDEX_NAME
   )
@@ -187,6 +188,9 @@ function isCommandFile(entry: Dirent): boolean {
     return false
   }
   if (entry.name.startsWith('_') || entry.name.startsWith('.')) {
+    return false
+  }
+  if (entry.name.endsWith('.d.ts')) {
     return false
   }
   if (!VALID_EXTENSIONS.has(extname(entry.name))) {


### PR DESCRIPTION
## Summary

- **Bug**: `kidd build` fails in CI (Node 24) with `@kidd-cli/cli@0.4.4` — Node's type stripping rejects `.d.ts` files under `node_modules`
- **Root cause**: `extname('build.d.ts')` returns `'.ts'`, so `.d.ts` files pass the `VALID_EXTENSIONS` check in both the runtime autoloader (`packages/core`) and the build-time scanner (`packages/bundler`). When the CLI is installed as a dependency, its `dist/commands/` directory contains `.d.ts` files (generated by `dts: true` in tsdown config), and the autoloader tries to `import()` them
- **Fix**: Add an explicit `entry.name.endsWith('.d.ts')` guard in `isCommandFile` and `findIndexEntry`/`findIndexInEntries` in both `packages/core/src/autoload.ts` and `packages/bundler/src/autoloader/scan-commands.ts`

## Test plan

- [x] New test: `should ignore .d.ts declaration files` in `packages/core/src/autoload.test.ts`
- [x] New test: `should skip .d.ts declaration files` in `packages/bundler/src/autoloader/scan-commands.test.ts`
- [x] `pnpm check` passes (typecheck + lint + format)
- [x] `pnpm test` passes (all 844+ tests)