### PR TITLE
fix(packages/bundler): move tsdown to dependencies for runtime resolution

### DIFF
--- a/.changeset/fix-bundler-tsdown-dep.md
+++ b/.changeset/fix-bundler-tsdown-dep.md
@@ -1,0 +1,5 @@
+---
+'@kidd-cli/bundler': patch
+---
+
+Move tsdown from devDependencies to dependencies to fix runtime module resolution

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -44,11 +44,11 @@
     "@kidd-cli/utils": "workspace:*",
     "es-toolkit": "catalog:",
     "ts-pattern": "catalog:",
+    "tsdown": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.3(@typescript/native-preview@7.0.0-dev.20260315.1)(typescript@5.9.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -224,9 +227,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.0
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.21.3(@typescript/native-preview@7.0.0-dev.20260315.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Moves `tsdown` from `devDependencies` to `dependencies` in `@kidd-cli/bundler`
- Fixes `Cannot find module 'semver/functions/satisfies.js'` error when consuming projects run `kidd build`
- Reduces bundled output from ~6700 lines to ~860 lines by properly externalizing tsdown

## Context

The bundler package imports `build` from `tsdown` at runtime, but `tsdown` was listed as a `devDependency`. Since tsdown auto-externalizes only `dependencies` and `peerDependencies`, it was inlining tsdown's entire internals — including CJS `require("semver/...")` calls that fail to resolve in consuming projects.

## Test plan

- [x] `pnpm build` passes locally
- [ ] Verify `kidd build` works in a consuming project (e.g. `@joggr/cli`)