### PR TITLE
fix(bundler): check bun exists in PATH before compile

### DIFF
--- a/.changeset/check-bun-exists.md
+++ b/.changeset/check-bun-exists.md
@@ -1,0 +1,5 @@
+---
+'@kidd-cli/bundler': patch
+---
+
+Check that `bun` exists in PATH before compiling; return a descriptive error when it is missing

--- a/packages/bundler/src/compile/compile.test.ts
+++ b/packages/bundler/src/compile/compile.test.ts
@@ -11,9 +11,23 @@ const mockExecFile = vi.mocked(execFile)
 const mockExistsSync = vi.mocked(existsSync)
 const mockReaddirSync = vi.mocked(readdirSync)
 
+/**
+ * Default execFile mock that succeeds for `bun --version` (existence check)
+ * and succeeds for all other calls. Override per-test to simulate failures.
+ */
+function mockExecFileSuccess() {
+  mockExecFile.mockImplementation(
+    // @ts-expect-error -- callback signature mismatch with overloaded execFile
+    (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+      cb(null, '')
+    }
+  )
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockReaddirSync.mockReturnValue([])
+  mockExecFileSuccess()
 })
 
 describe('compile operation', () => {
@@ -39,6 +53,23 @@ describe('compile operation', () => {
     })
   })
 
+  it('should return err when bun is not installed', async () => {
+    mockExecFile.mockImplementation(
+      // @ts-expect-error -- callback signature mismatch with overloaded execFile
+      (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+        cb(new Error('spawn bun ENOENT'), '')
+      }
+    )
+
+    const [error, output] = await compile({ config: {}, cwd: '/project' })
+
+    expect(output).toBeNull()
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toMatchObject({
+      message: expect.stringContaining('bun is not installed'),
+    })
+  })
+
   it('should return err when bundled entry does not exist', async () => {
     mockExistsSync.mockReturnValue(false)
 
@@ -51,12 +82,19 @@ describe('compile operation', () => {
 
   it('should return err when bun build fails', async () => {
     mockExistsSync.mockReturnValue(true)
-    mockExecFile.mockImplementation(
-      // @ts-expect-error -- callback signature mismatch with overloaded execFile
-      (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
-        cb(new Error('bun build crashed'), '')
-      }
-    )
+    mockExecFile
+      .mockImplementationOnce(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+          cb(null, '1.0.0')
+        }
+      )
+      .mockImplementation(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+          cb(new Error('bun build crashed'), '')
+        }
+      )
 
     const [error, output] = await compile({ config: {}, cwd: '/project' })
 
@@ -67,16 +105,23 @@ describe('compile operation', () => {
 
   it('should include stderr in error message when verbose is true', async () => {
     mockExistsSync.mockReturnValue(true)
-    mockExecFile.mockImplementation(
-      // @ts-expect-error -- callback signature mismatch with overloaded execFile
-      (
-        _cmd: string,
-        _args: string[],
-        cb: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        cb(new Error('bun build crashed'), '', 'error: could not resolve "chokidar"')
-      }
-    )
+    mockExecFile
+      .mockImplementationOnce(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+          cb(null, '1.0.0')
+        }
+      )
+      .mockImplementation(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (
+          _cmd: string,
+          _args: string[],
+          cb: (err: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          cb(new Error('bun build crashed'), '', 'error: could not resolve "chokidar"')
+        }
+      )
 
     const [error] = await compile({
       config: { compile: { name: 'my-app', targets: ['linux-x64'] } },
@@ -91,16 +136,23 @@ describe('compile operation', () => {
 
   it('should not include stderr in error message when verbose is false', async () => {
     mockExistsSync.mockReturnValue(true)
-    mockExecFile.mockImplementation(
-      // @ts-expect-error -- callback signature mismatch with overloaded execFile
-      (
-        _cmd: string,
-        _args: string[],
-        cb: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        cb(new Error('bun build crashed'), '', 'error: could not resolve "chokidar"')
-      }
-    )
+    mockExecFile
+      .mockImplementationOnce(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string) => void) => {
+          cb(null, '1.0.0')
+        }
+      )
+      .mockImplementation(
+        // @ts-expect-error -- callback signature mismatch with overloaded execFile
+        (
+          _cmd: string,
+          _args: string[],
+          cb: (err: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          cb(new Error('bun build crashed'), '', 'error: could not resolve "chokidar"')
+        }
+      )
 
     const [error] = await compile({
       config: { compile: { name: 'my-app', targets: ['linux-x64'] } },

--- a/packages/bundler/src/compile/compile.ts
+++ b/packages/bundler/src/compile/compile.ts
@@ -35,6 +35,11 @@ const COMPILE_TARGET_LABELS: Readonly<Record<CompileTarget, string>> = {
  * @returns A result tuple with compile output on success or an Error on failure.
  */
 export async function compile(params: CompileParams): AsyncResult<CompileOutput> {
+  const [bunCheckError] = await checkBunExists()
+  if (bunCheckError) {
+    return err(bunCheckError)
+  }
+
   const resolved = resolveConfig(params)
   const bundledEntry = detectBuildEntry(resolved.buildOutDir)
 
@@ -210,6 +215,31 @@ function formatCompileError(target: CompileTarget, execError: Error, verbose: bo
   }
 
   return header
+}
+
+/**
+ * Check whether the `bun` binary is available on the system PATH.
+ *
+ * @private
+ * @returns A result tuple with `null` on success or an Error when `bun` is not found.
+ */
+function checkBunExists(): AsyncResult<null> {
+  return new Promise((resolve) => {
+    execFileCb('bun', ['--version'], (error) => {
+      if (error) {
+        resolve(
+          err(
+            new Error(
+              'bun is not installed or not found in PATH. Install it from https://bun.sh to use compile.'
+            )
+          )
+        )
+        return
+      }
+
+      resolve(ok(null))
+    })
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a `bun --version` check at the start of `compile()` to verify `bun` is available in PATH
- Returns a clear error message with install link when `bun` is missing instead of a cryptic ENOENT
- Adds test coverage for the missing-bun scenario and updates existing tests to account for the new check

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (oxlint)
- [x] `pnpm format` passes (oxfmt)
- [x] `pnpm test --filter=@kidd-cli/bundler` — all 108 tests pass