### PR TITLE
feat(core): configurable built-in options and improved aliases

### DIFF
--- a/.changeset/configurable-builtins.md
+++ b/.changeset/configurable-builtins.md
@@ -1,0 +1,10 @@
+---
+'@kidd-cli/core': minor
+---
+
+Add configurable built-in options and improve aliases
+
+- Add `builtins` field to `CliOptions` for toggling `--version` and `--working-directory`
+- Rename `--cwd` to `--working-directory` with `--cwd` as alias
+- Add `-h` alias for `--help`, `-V` alias for `--version`
+- `--help` / `-h` is always registered and cannot be disabled

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -547,3 +547,63 @@ describe('help', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 })
+
+describe('builtins', () => {
+  it('should register --working-directory with --cwd alias by default', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      run: command({ description: 'Run', handler }),
+    }
+
+    setArgv('run')
+    await runTestCli({ commands, name: 'test-cli', version: '1.0.0' })
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('should disable --version when builtins.version is false', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      run: command({ description: 'Run', handler }),
+    }
+
+    setArgv('run')
+    await runTestCli({
+      builtins: { version: false },
+      commands,
+      name: 'test-cli',
+      version: '1.0.0',
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('should disable --working-directory when builtins.workingDirectory is false', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      run: command({ description: 'Run', handler }),
+    }
+
+    setArgv('run', '--working-directory', '/tmp')
+    await runTestCli({
+      builtins: { workingDirectory: false },
+      commands,
+      name: 'test-cli',
+      version: '1.0.0',
+    })
+
+    expect(lifecycle.getExitSpy()).toHaveBeenCalled()
+  })
+
+  it('should default all builtins to true when omitted', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      run: command({ description: 'Run', handler }),
+    }
+
+    setArgv('run')
+    await runTestCli({ commands, name: 'test-cli', version: '1.0.0' })
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 
 import { DEFAULT_EXIT_CODE, isContextError } from '@/context/index.js'
 import type {
+  BuiltinOptions,
   CliOptions,
   CommandMap,
   CommandsConfig,
@@ -43,16 +44,26 @@ export async function cli<TSchema extends z.ZodType = z.ZodType>(
       return versionError
     }
 
-    const program = yargs(process.argv.slice(ARGV_SLICE_START))
-      .scriptName(options.name)
-      .version(version)
-      .strict()
-      .help()
-      .option('cwd', {
+    const builtins = resolveBuiltins(options.builtins)
+
+    const program = yargs(process.argv.slice(ARGV_SLICE_START)).scriptName(options.name).strict()
+
+    if (builtins.version) {
+      program.version(version).alias('version', 'V')
+    } else {
+      program.version(false)
+    }
+
+    program.help().alias('help', 'h')
+
+    if (builtins.workingDirectory) {
+      program.option('working-directory', {
+        alias: 'cwd',
         describe: 'Set the working directory',
         global: true,
         type: 'string',
       })
+    }
 
     if (options.description) {
       program.usage(options.description)
@@ -255,7 +266,7 @@ async function resolveCommandsFromConfig(): Promise<ResolvedCommands> {
 }
 
 /**
- * Change the process working directory when `--cwd` is provided.
+ * Change the process working directory when `--working-directory` is provided.
  *
  * Resolves the value to an absolute path and calls `process.chdir()` so
  * that all downstream `process.cwd()` calls reflect the override.
@@ -264,8 +275,22 @@ async function resolveCommandsFromConfig(): Promise<ResolvedCommands> {
  * @param argv - The parsed argv record from yargs.
  */
 function applyCwd(argv: Record<string, unknown>): void {
-  if (isString(argv.cwd)) {
-    process.chdir(resolve(argv.cwd))
+  if (isString(argv.workingDirectory)) {
+    process.chdir(resolve(argv.workingDirectory))
+  }
+}
+
+/**
+ * Resolve builtin option toggles, defaulting each to `true`.
+ *
+ * @private
+ * @param builtins - The optional user-provided builtin overrides.
+ * @returns A fully resolved builtins object with no undefined fields.
+ */
+function resolveBuiltins(builtins: BuiltinOptions | undefined): Required<BuiltinOptions> {
+  return {
+    version: builtins?.version !== false,
+    workingDirectory: builtins?.workingDirectory !== false,
   }
 }
 

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -101,6 +101,26 @@ export interface HelpOptions {
 }
 
 /**
+ * Toggle individual built-in global options (`--version`,
+ * `--working-directory`).
+ *
+ * Every field defaults to `true` when omitted. Set a field to `false`
+ * to prevent that option from being registered on the yargs program.
+ *
+ * `--help` / `-h` is always registered and cannot be disabled.
+ */
+export interface BuiltinOptions {
+  /**
+   * Register `--version` / `-V`. Defaults to `true`.
+   */
+  readonly version?: boolean
+  /**
+   * Register `--working-directory` / `--cwd`. Defaults to `true`.
+   */
+  readonly workingDirectory?: boolean
+}
+
+/**
  * Options passed to `cli()`.
  */
 export interface CliOptions<TSchema extends z.ZodType = z.ZodType> {
@@ -162,6 +182,11 @@ export interface CliOptions<TSchema extends z.ZodType = z.ZodType> {
    * spinner is created automatically.
    */
   readonly spinner?: Spinner
+  /**
+   * Toggle built-in global options (`--help`, `--version`,
+   * `--working-directory`). All default to `true` when omitted.
+   */
+  readonly builtins?: BuiltinOptions
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -37,6 +37,7 @@ export type {
 } from './command.js'
 
 export type {
+  BuiltinOptions,
   CliConfig,
   CliConfigOptions,
   CliFn,


### PR DESCRIPTION
## Summary

- Add `builtins` field to `CliOptions` for toggling `--version` and `--working-directory`
- Rename `--cwd` to `--working-directory` with `--cwd` kept as alias
- Add `-h` alias for `--help`, `-V` alias for `--version`
- `--help` / `-h` is always registered and cannot be disabled
- Export new `BuiltinOptions` type from `@kidd-cli/core`

## Test plan

- [x] Existing tests pass (28/28)
- [x] New `builtins` tests added (4 cases: default registration, disable version, disable working-directory, defaults to true)
- [x] Typecheck clean
- [x] Lint clean
- [x] Format clean