### PR TITLE
feat(bundler): add verbose error logging to tsdown build and watch

### DIFF
--- a/.changeset/bundler-verbose-errors.md
+++ b/.changeset/bundler-verbose-errors.md
@@ -1,0 +1,5 @@
+---
+'@kidd-cli/bundler': minor
+---
+
+Add verbose error logging to tsdown build and watch steps, matching the existing bun compile behavior

--- a/packages/bundler/src/build/build.ts
+++ b/packages/bundler/src/build/build.ts
@@ -7,6 +7,31 @@ import { clean } from '../utils/clean.js'
 import { resolveBuildEntry } from '../utils/resolve-build-entry.js'
 import type { AsyncBundlerResult, BuildOutput, ResolvedBundlerConfig } from '../types.js'
 
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a descriptive error message for a failed tsdown operation.
+ *
+ * @param phase - The tsdown phase that failed (build or watch).
+ * @param error - The error returned by tsdown.
+ * @param verbose - Whether to include the full error details.
+ * @returns A formatted error message.
+ */
+export function formatBuildError(phase: 'build' | 'watch', error: unknown, verbose: boolean): string {
+  const header = `tsdown ${phase} failed`
+
+  if (!verbose) {
+    return header
+  }
+
+  const detail = error instanceof Error ? error.message : String(error)
+  if (detail.trim().length > 0) {
+    return `${header}\n${detail.trim()}`
+  }
+
+  return header
+}
+
 /**
  * Run the tsdown build with a resolved config.
  *
@@ -19,6 +44,7 @@ import type { AsyncBundlerResult, BuildOutput, ResolvedBundlerConfig } from '../
 export async function build(params: {
   readonly resolved: ResolvedBundlerConfig
   readonly compile: boolean
+  readonly verbose?: boolean
 }): AsyncBundlerResult<BuildOutput> {
   if (params.resolved.build.clean) {
     await clean({ resolved: params.resolved, compile: params.compile })
@@ -31,7 +57,7 @@ export async function build(params: {
 
   const [buildError] = await attemptAsync(() => tsdownBuild(inlineConfig))
   if (buildError) {
-    return err(new Error('tsdown build failed', { cause: buildError }))
+    return err(new Error(formatBuildError('build', buildError, params.verbose ?? false), { cause: buildError }))
   }
 
   const entryFile = await resolveBuildEntry(params.resolved.buildOutDir)

--- a/packages/bundler/src/build/build.ts
+++ b/packages/bundler/src/build/build.ts
@@ -33,7 +33,12 @@ export async function build(params: {
 
   const [buildError] = await attemptAsync(() => tsdownBuild(inlineConfig))
   if (buildError) {
-    return err(new Error(formatBuildError('build', buildError, params.verbose ?? false), { cause: buildError }))
+    return err(
+      new Error(
+        formatBuildError({ phase: 'build', error: buildError, verbose: params.verbose ?? false }),
+        { cause: buildError }
+      )
+    )
   }
 
   const entryFile = await resolveBuildEntry(params.resolved.buildOutDir)

--- a/packages/bundler/src/build/build.ts
+++ b/packages/bundler/src/build/build.ts
@@ -4,33 +4,9 @@ import { build as tsdownBuild } from 'tsdown'
 
 import { resolveBuildVars, toTsdownBuildConfig } from './config.js'
 import { clean } from '../utils/clean.js'
+import { formatBuildError } from '../utils/format-error.js'
 import { resolveBuildEntry } from '../utils/resolve-build-entry.js'
 import type { AsyncBundlerResult, BuildOutput, ResolvedBundlerConfig } from '../types.js'
-
-// ---------------------------------------------------------------------------
-
-/**
- * Build a descriptive error message for a failed tsdown operation.
- *
- * @param phase - The tsdown phase that failed (build or watch).
- * @param error - The error returned by tsdown.
- * @param verbose - Whether to include the full error details.
- * @returns A formatted error message.
- */
-export function formatBuildError(phase: 'build' | 'watch', error: unknown, verbose: boolean): string {
-  const header = `tsdown ${phase} failed`
-
-  if (!verbose) {
-    return header
-  }
-
-  const detail = error instanceof Error ? error.message : String(error)
-  if (detail.trim().length > 0) {
-    return `${header}\n${detail.trim()}`
-  }
-
-  return header
-}
 
 /**
  * Run the tsdown build with a resolved config.

--- a/packages/bundler/src/build/watch.ts
+++ b/packages/bundler/src/build/watch.ts
@@ -26,7 +26,12 @@ export async function watch(params: {
 
   const [watchError] = await attemptAsync(() => tsdownBuild(watchConfig))
   if (watchError) {
-    return err(new Error(formatBuildError('watch', watchError, params.verbose ?? false), { cause: watchError }))
+    return err(
+      new Error(
+        formatBuildError({ phase: 'watch', error: watchError, verbose: params.verbose ?? false }),
+        { cause: watchError }
+      )
+    )
   }
 
   return ok()

--- a/packages/bundler/src/build/watch.ts
+++ b/packages/bundler/src/build/watch.ts
@@ -4,7 +4,7 @@ import { build as tsdownBuild } from 'tsdown'
 
 import { toTsdownWatchConfig } from './config.js'
 import type { AsyncBundlerResult, ResolvedBundlerConfig } from '../types.js'
-import { formatBuildError } from './build.js'
+import { formatBuildError } from '../utils/format-error.js'
 
 /**
  * Start a watch-mode build using tsdown.

--- a/packages/bundler/src/build/watch.ts
+++ b/packages/bundler/src/build/watch.ts
@@ -4,18 +4,20 @@ import { build as tsdownBuild } from 'tsdown'
 
 import { toTsdownWatchConfig } from './config.js'
 import type { AsyncBundlerResult, ResolvedBundlerConfig } from '../types.js'
+import { formatBuildError } from './build.js'
 
 /**
  * Start a watch-mode build using tsdown.
  *
  * The returned promise resolves only when tsdown's watch terminates (typically on process exit).
  *
- * @param params - The resolved config and optional success callback.
+ * @param params - The resolved config, optional success callback, and verbose flag.
  * @returns A result tuple with void on success or an Error on failure.
  */
 export async function watch(params: {
   readonly resolved: ResolvedBundlerConfig
   readonly onSuccess?: () => void | Promise<void>
+  readonly verbose?: boolean
 }): AsyncBundlerResult<void> {
   const watchConfig = toTsdownWatchConfig({
     config: params.resolved,
@@ -24,7 +26,7 @@ export async function watch(params: {
 
   const [watchError] = await attemptAsync(() => tsdownBuild(watchConfig))
   if (watchError) {
-    return err(new Error('tsdown watch failed', { cause: watchError }))
+    return err(new Error(formatBuildError('watch', watchError, params.verbose ?? false), { cause: watchError }))
   }
 
   return ok()

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -8,6 +8,7 @@ import { compile } from './compile/compile.js'
 import type {
   AsyncBundlerResult,
   BuildOutput,
+  BuildOverrides,
   Bundler,
   BundlerLifecycle,
   CompileOutput,
@@ -51,10 +52,10 @@ export async function createBundler(params: CreateBundlerParams): Promise<Bundle
   }
 
   return {
-    build: async (): AsyncBundlerResult<BuildOutput> => {
-      const lifecycle = resolveLifecycle(baseLifecycle)
+    build: async (overrides: BuildOverrides = {}): AsyncBundlerResult<BuildOutput> => {
+      const lifecycle = resolveLifecycle(baseLifecycle, overrides)
       await lifecycle.onStart({ phase: 'build' })
-      const result = await build({ compile: hasCompile, resolved })
+      const result = await build({ compile: hasCompile, resolved, verbose: overrides.verbose })
       await lifecycle.onFinish({ phase: 'build' })
       return result
     },
@@ -62,7 +63,7 @@ export async function createBundler(params: CreateBundlerParams): Promise<Bundle
     watch: async (overrides: WatchOverrides = {}): AsyncBundlerResult<void> => {
       const lifecycle = resolveLifecycle(baseLifecycle, overrides)
       await lifecycle.onStart({ phase: 'watch' })
-      const result = await watch({ onSuccess: overrides.onSuccess, resolved })
+      const result = await watch({ onSuccess: overrides.onSuccess, resolved, verbose: overrides.verbose })
       await lifecycle.onFinish({ phase: 'watch' })
       return result
     },

--- a/packages/bundler/src/types.ts
+++ b/packages/bundler/src/types.ts
@@ -102,9 +102,16 @@ export interface CreateBundlerParams extends BundlerLifecycle {
  * A bundler instance with build, watch, and compile methods.
  */
 export interface Bundler {
-  readonly build: () => AsyncBundlerResult<BuildOutput>
+  readonly build: (params?: BuildOverrides) => AsyncBundlerResult<BuildOutput>
   readonly watch: (params?: WatchOverrides) => AsyncBundlerResult<void>
   readonly compile: (params?: CompileOverrides) => AsyncBundlerResult<CompileOutput>
+}
+
+/**
+ * Per-call overrides for build.
+ */
+export interface BuildOverrides extends BundlerLifecycle {
+  readonly verbose?: boolean
 }
 
 /**
@@ -112,6 +119,7 @@ export interface Bundler {
  */
 export interface WatchOverrides extends BundlerLifecycle {
   readonly onSuccess?: () => void | Promise<void>
+  readonly verbose?: boolean
 }
 
 /**

--- a/packages/bundler/src/utils/format-error.test.ts
+++ b/packages/bundler/src/utils/format-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBuildError } from './format-error.js'
+
+describe(formatBuildError, () => {
+  it('returns only the header when verbose is false', () => {
+    const result = formatBuildError('build', new Error('kaboom'), false)
+    expect(result).toBe('tsdown build failed')
+  })
+
+  it('includes the error message when verbose is true', () => {
+    const result = formatBuildError('build', new Error('module not found'), true)
+    expect(result).toBe('tsdown build failed\nmodule not found')
+  })
+
+  it('uses the watch phase in the header', () => {
+    const result = formatBuildError('watch', new Error('timeout'), false)
+    expect(result).toBe('tsdown watch failed')
+  })
+
+  it('coerces a non-Error value to a message when verbose', () => {
+    const result = formatBuildError('build', 'string error', true)
+    expect(result).toBe('tsdown build failed\nstring error')
+  })
+
+  it('coerces a numeric value to a message when verbose', () => {
+    const result = formatBuildError('watch', 42, true)
+    expect(result).toBe('tsdown watch failed\n42')
+  })
+
+  it('returns only the header when error message is whitespace and verbose', () => {
+    const result = formatBuildError('build', new Error('   '), true)
+    expect(result).toBe('tsdown build failed')
+  })
+})

--- a/packages/bundler/src/utils/format-error.test.ts
+++ b/packages/bundler/src/utils/format-error.test.ts
@@ -4,32 +4,36 @@ import { formatBuildError } from './format-error.js'
 
 describe(formatBuildError, () => {
   it('returns only the header when verbose is false', () => {
-    const result = formatBuildError('build', new Error('kaboom'), false)
+    const result = formatBuildError({ phase: 'build', error: new Error('kaboom'), verbose: false })
     expect(result).toBe('tsdown build failed')
   })
 
   it('includes the error message when verbose is true', () => {
-    const result = formatBuildError('build', new Error('module not found'), true)
+    const result = formatBuildError({
+      phase: 'build',
+      error: new Error('module not found'),
+      verbose: true,
+    })
     expect(result).toBe('tsdown build failed\nmodule not found')
   })
 
   it('uses the watch phase in the header', () => {
-    const result = formatBuildError('watch', new Error('timeout'), false)
+    const result = formatBuildError({ phase: 'watch', error: new Error('timeout'), verbose: false })
     expect(result).toBe('tsdown watch failed')
   })
 
   it('coerces a non-Error value to a message when verbose', () => {
-    const result = formatBuildError('build', 'string error', true)
+    const result = formatBuildError({ phase: 'build', error: 'string error', verbose: true })
     expect(result).toBe('tsdown build failed\nstring error')
   })
 
   it('coerces a numeric value to a message when verbose', () => {
-    const result = formatBuildError('watch', 42, true)
+    const result = formatBuildError({ phase: 'watch', error: 42, verbose: true })
     expect(result).toBe('tsdown watch failed\n42')
   })
 
   it('returns only the header when error message is whitespace and verbose', () => {
-    const result = formatBuildError('build', new Error('   '), true)
+    const result = formatBuildError({ phase: 'build', error: new Error('   '), verbose: true })
     expect(result).toBe('tsdown build failed')
   })
 })

--- a/packages/bundler/src/utils/format-error.ts
+++ b/packages/bundler/src/utils/format-error.ts
@@ -1,4 +1,5 @@
 import { toError } from '@kidd-cli/utils/fp'
+import { match } from 'ts-pattern'
 
 /**
  * Build a descriptive error message for a failed tsdown operation.
@@ -6,22 +7,18 @@ import { toError } from '@kidd-cli/utils/fp'
  * When verbose is false only a short header is returned. When verbose is true
  * the underlying error message is appended so callers get actionable detail.
  *
- * @param phase - The tsdown phase that failed (build or watch).
- * @param error - The error returned by tsdown (unknown from attemptAsync).
- * @param verbose - Whether to include the full error details.
+ * @param params - The phase, error, and verbose flag.
  * @returns A formatted error message.
  */
-export function formatBuildError(phase: 'build' | 'watch', error: unknown, verbose: boolean): string {
-  const header = `tsdown ${phase} failed`
+export function formatBuildError(params: {
+  readonly phase: 'build' | 'watch'
+  readonly error: unknown
+  readonly verbose: boolean
+}): string {
+  const header = `tsdown ${params.phase} failed`
+  const detail = toError(params.error).message.trim()
 
-  if (!verbose) {
-    return header
-  }
-
-  const detail = toError(error).message
-  if (detail.trim().length > 0) {
-    return `${header}\n${detail.trim()}`
-  }
-
-  return header
+  return match({ verbose: params.verbose, hasDetail: detail.length > 0 })
+    .with({ verbose: true, hasDetail: true }, () => `${header}\n${detail}`)
+    .otherwise(() => header)
 }

--- a/packages/bundler/src/utils/format-error.ts
+++ b/packages/bundler/src/utils/format-error.ts
@@ -1,0 +1,27 @@
+import { toError } from '@kidd-cli/utils/fp'
+
+/**
+ * Build a descriptive error message for a failed tsdown operation.
+ *
+ * When verbose is false only a short header is returned. When verbose is true
+ * the underlying error message is appended so callers get actionable detail.
+ *
+ * @param phase - The tsdown phase that failed (build or watch).
+ * @param error - The error returned by tsdown (unknown from attemptAsync).
+ * @param verbose - Whether to include the full error details.
+ * @returns A formatted error message.
+ */
+export function formatBuildError(phase: 'build' | 'watch', error: unknown, verbose: boolean): string {
+  const header = `tsdown ${phase} failed`
+
+  if (!verbose) {
+    return header
+  }
+
+  const detail = toError(error).message
+  if (detail.trim().length > 0) {
+    return `${header}\n${detail.trim()}`
+  }
+
+  return header
+}


### PR DESCRIPTION
## Summary
- Adds `verbose` error logging to tsdown `build()` and `watch()` steps, matching the existing behavior in bun `compile()`
- Introduces `formatBuildError()` helper shared by both build and watch, which includes the full error message when verbose is enabled
- Adds `BuildOverrides` type and `verbose` flag to `WatchOverrides` for per-call control

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm test` passes (116 tests)