### PR TITLE
feat(bundler): disable Bun env autoloading in compiled binaries

### DIFF
--- a/.changeset/disable-bun-env-autoloading.md
+++ b/.changeset/disable-bun-env-autoloading.md
@@ -1,0 +1,6 @@
+---
+'@kidd-cli/config': minor
+'@kidd-cli/bundler': minor
+---
+
+Disable Bun's automatic `.env` and `bunfig.toml` loading in compiled binaries by default. Adds `autoloadDotenv` option to compile config for opt-in `.env` loading. `bunfig.toml` loading is always disabled.

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -63,7 +63,11 @@ export async function createBundler(params: CreateBundlerParams): Promise<Bundle
     watch: async (overrides: WatchOverrides = {}): AsyncBundlerResult<void> => {
       const lifecycle = resolveLifecycle(baseLifecycle, overrides)
       await lifecycle.onStart({ phase: 'watch' })
-      const result = await watch({ onSuccess: overrides.onSuccess, resolved, verbose: overrides.verbose })
+      const result = await watch({
+        onSuccess: overrides.onSuccess,
+        resolved,
+        verbose: overrides.verbose,
+      })
       await lifecycle.onFinish({ phase: 'watch' })
       return result
     },

--- a/packages/bundler/src/compile/compile.test.ts
+++ b/packages/bundler/src/compile/compile.test.ts
@@ -272,9 +272,22 @@ describe('compile operation', () => {
     })
   })
 
-  it('should pass --no-compile-autoload-dotenv when autoloadDotenv is false', async () => {
+  it('should pass --no-compile-autoload-dotenv by default when autoloadDotenv is not configured', async () => {
     await compile({
       resolved: makeResolved({ targets: ['linux-x64'], name: 'my-app' }),
+      lifecycle: noopLifecycle,
+    })
+
+    expect(mockProcessExec).toHaveBeenCalledWith({
+      cmd: 'bun',
+      args: expect.arrayContaining(['--no-compile-autoload-dotenv']),
+      cwd: '/project',
+    })
+  })
+
+  it('should pass --no-compile-autoload-dotenv when autoloadDotenv is explicitly false', async () => {
+    await compile({
+      resolved: makeResolved({ targets: ['linux-x64'], name: 'my-app', autoloadDotenv: false }),
       lifecycle: noopLifecycle,
     })
 

--- a/packages/bundler/src/compile/compile.test.ts
+++ b/packages/bundler/src/compile/compile.test.ts
@@ -27,6 +27,7 @@ const noopLifecycle = {
 function makeResolved(overrides?: {
   readonly targets?: readonly string[]
   readonly name?: string
+  readonly autoloadDotenv?: boolean
 }): Parameters<typeof compile>[0]['resolved'] {
   return {
     entry: '/project/src/index.ts',
@@ -42,6 +43,7 @@ function makeResolved(overrides?: {
       define: {},
     },
     compile: {
+      autoloadDotenv: overrides?.autoloadDotenv ?? false,
       targets: (overrides?.targets ?? []) as readonly CompileTarget[],
       name: overrides?.name ?? 'cli',
     },
@@ -255,6 +257,49 @@ describe('compile operation', () => {
     expect(stepStarts).toContain('linux-x64')
     expect(stepFinishes).toContain('darwin-arm64')
     expect(stepFinishes).toContain('linux-x64')
+  })
+
+  it('should always pass --no-compile-autoload-bunfig', async () => {
+    await compile({
+      resolved: makeResolved({ targets: ['linux-x64'], name: 'my-app' }),
+      lifecycle: noopLifecycle,
+    })
+
+    expect(mockProcessExec).toHaveBeenCalledWith({
+      cmd: 'bun',
+      args: expect.arrayContaining(['--no-compile-autoload-bunfig']),
+      cwd: '/project',
+    })
+  })
+
+  it('should pass --no-compile-autoload-dotenv when autoloadDotenv is false', async () => {
+    await compile({
+      resolved: makeResolved({ targets: ['linux-x64'], name: 'my-app' }),
+      lifecycle: noopLifecycle,
+    })
+
+    expect(mockProcessExec).toHaveBeenCalledWith({
+      cmd: 'bun',
+      args: expect.arrayContaining(['--no-compile-autoload-dotenv']),
+      cwd: '/project',
+    })
+  })
+
+  it('should not pass --no-compile-autoload-dotenv when autoloadDotenv is true', async () => {
+    await compile({
+      resolved: makeResolved({
+        targets: ['linux-x64'],
+        name: 'my-app',
+        autoloadDotenv: true,
+      }),
+      lifecycle: noopLifecycle,
+    })
+
+    expect(mockProcessExec).toHaveBeenCalledWith({
+      cmd: 'bun',
+      args: expect.not.arrayContaining(['--no-compile-autoload-dotenv']),
+      cwd: '/project',
+    })
   })
 
   it('should invoke bun with --compile and --outfile args', async () => {

--- a/packages/bundler/src/compile/compile.ts
+++ b/packages/bundler/src/compile/compile.ts
@@ -52,6 +52,7 @@ export async function compile(params: {
   const isMultiTarget = targets.length > 1
 
   const results = await compileTargetsSequentially({
+    autoloadDotenv: params.resolved.compile.autoloadDotenv,
     bundledEntry,
     cwd: params.resolved.cwd,
     isMultiTarget,
@@ -99,6 +100,7 @@ export function resolveTargetLabel(target: CompileTarget): string {
  * @returns The accumulated result tuples for each target.
  */
 async function compileTargetsSequentially(params: {
+  readonly autoloadDotenv: boolean
   readonly bundledEntry: string
   readonly cwd: string
   readonly isMultiTarget: boolean
@@ -118,6 +120,7 @@ async function compileTargetsSequentially(params: {
     }
 
     const result = await compileSingleTarget({
+      autoloadDotenv: params.autoloadDotenv,
       bundledEntry: params.bundledEntry,
       cwd: params.cwd,
       isMultiTarget: params.isMultiTarget,
@@ -143,6 +146,7 @@ async function compileTargetsSequentially(params: {
  * @returns A result tuple with the compiled binary info or an error.
  */
 async function compileSingleTarget(params: {
+  readonly autoloadDotenv: boolean
   readonly bundledEntry: string
   readonly cwd: string
   readonly outDir: string
@@ -162,6 +166,7 @@ async function compileSingleTarget(params: {
   const args = [
     'build',
     '--compile',
+    ...resolveAutoloadFlags({ autoloadDotenv: params.autoloadDotenv }),
     params.bundledEntry,
     '--outfile',
     outfile,
@@ -256,6 +261,26 @@ function formatCompileError(target: CompileTarget, execError: Error, verbose: bo
   }
 
   return header
+}
+
+/**
+ * Build the CLI flags that control Bun's compile-time config autoloading.
+ *
+ * `bunfig.toml` loading is always disabled — kidd CLIs should never load
+ * Bun runtime config. `.env` loading is controlled by the `autoloadDotenv`
+ * option (disabled by default).
+ *
+ * @private
+ * @param params - The autoload settings.
+ * @returns An array of CLI flag strings.
+ */
+function resolveAutoloadFlags(params: { readonly autoloadDotenv: boolean }): readonly string[] {
+  const candidates = [
+    { enabled: false, flag: '--no-compile-autoload-bunfig' },
+    { enabled: params.autoloadDotenv, flag: '--no-compile-autoload-dotenv' },
+  ] as const
+
+  return candidates.filter((c) => !c.enabled).map((c) => c.flag)
 }
 
 /**

--- a/packages/bundler/src/types.ts
+++ b/packages/bundler/src/types.ts
@@ -19,6 +19,7 @@ export interface ResolvedBuildOptions {
  * Fully resolved compile options with all defaults applied.
  */
 export interface ResolvedCompileOptions {
+  readonly autoloadDotenv: boolean
   readonly targets: readonly CompileTarget[]
   readonly name: string
 }

--- a/packages/bundler/src/utils/resolve-config.test.ts
+++ b/packages/bundler/src/utils/resolve-config.test.ts
@@ -46,6 +46,10 @@ describe('config resolution', () => {
       })
     })
 
+    it('should default autoloadDotenv to false', () => {
+      expect(resolved.compile.autoloadDotenv).toBeFalsy()
+    })
+
     it('should use binaryName as compile name when no config name', () => {
       expect(resolved.compile.name).toBe('cli')
     })
@@ -75,6 +79,7 @@ describe('config resolution', () => {
         },
         commands: './src/commands',
         compile: {
+          autoloadDotenv: true,
           name: 'my-cli',
           out: './bin',
           targets: ['darwin-arm64'],
@@ -112,6 +117,10 @@ describe('config resolution', () => {
         sourcemap: false,
         target: 'node22',
       })
+    })
+
+    it('should use custom autoloadDotenv value', () => {
+      expect(resolved.compile.autoloadDotenv).toBeTruthy()
     })
 
     it('should prefer config compile name over binaryName', () => {

--- a/packages/bundler/src/utils/resolve-config.ts
+++ b/packages/bundler/src/utils/resolve-config.ts
@@ -71,6 +71,7 @@ export function resolveConfig(params: {
     buildOutDir,
     commands,
     compile: {
+      autoloadDotenv: compileOpts.autoloadDotenv ?? false,
       name: compileOpts.name ?? params.binaryName,
       targets: compileOpts.targets ?? [],
     },

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -60,6 +60,14 @@ export interface CompileOptions {
    * Binary name. Defaults to cli name.
    */
   name?: string
+  /**
+   * Load `.env` files at runtime in the compiled binary. Default: false.
+   *
+   * When disabled, the compiled binary will not auto-load `.env` files from
+   * the working directory. Use the kidd auth dotenv strategy for explicit
+   * `.env` loading instead.
+   */
+  autoloadDotenv?: boolean
 }
 
 /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -67,7 +67,7 @@ export interface CompileOptions {
    * the working directory. Use the kidd auth dotenv strategy for explicit
    * `.env` loading instead.
    */
-  autoloadDotenv?: boolean
+  readonly autoloadDotenv?: boolean
 }
 
 /**

--- a/packages/config/src/utils/schema.test.ts
+++ b/packages/config/src/utils/schema.test.ts
@@ -13,7 +13,7 @@ describe('KiddConfigSchema schema', () => {
     const result = KiddConfigSchema.safeParse({
       build: { external: ['pg'], minify: true, out: './dist', sourcemap: false, target: 'node20' },
       commands: './commands',
-      compile: { name: 'my-cli', out: './bin', targets: ['linux-x64', 'darwin-arm64'] },
+      compile: { autoloadDotenv: true, name: 'my-cli', out: './bin', targets: ['linux-x64', 'darwin-arm64'] },
       entry: './src/index.ts',
       include: ['assets/**'],
     })
@@ -57,14 +57,6 @@ describe('KiddConfigSchema schema', () => {
 
   it('should accept compile: false (boolean shorthand)', () => {
     const result = KiddConfigSchema.safeParse({ compile: false })
-
-    expect(result.success).toBeTruthy()
-  })
-
-  it('should accept compile options with autoloadDotenv', () => {
-    const result = KiddConfigSchema.safeParse({
-      compile: { autoloadDotenv: true },
-    })
 
     expect(result.success).toBeTruthy()
   })

--- a/packages/config/src/utils/schema.test.ts
+++ b/packages/config/src/utils/schema.test.ts
@@ -60,6 +60,14 @@ describe('KiddConfigSchema schema', () => {
 
     expect(result.success).toBeTruthy()
   })
+
+  it('should accept compile options with autoloadDotenv', () => {
+    const result = KiddConfigSchema.safeParse({
+      compile: { autoloadDotenv: true },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
 })
 
 describe(validateConfig, () => {

--- a/packages/config/src/utils/schema.ts
+++ b/packages/config/src/utils/schema.ts
@@ -39,6 +39,7 @@ const BuildOptionsSchema = z
  */
 const CompileOptionsSchema = z
   .object({
+    autoloadDotenv: z.boolean().optional(),
     name: z.string().optional(),
     out: z.string().optional(),
     targets: z.array(CompileTargetSchema).optional(),


### PR DESCRIPTION
## Summary

- Always disables `bunfig.toml` autoloading in compiled binaries (`--no-compile-autoload-bunfig`)
- Disables `.env` autoloading by default (`--no-compile-autoload-dotenv`), opt-in via `autoloadDotenv: true` in compile config
- Prevents Bun from leaking `.env` vars into `process.env` before kidd's auth dotenv strategy runs

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm format` passes
- [x] `pnpm test` passes — 3 new compile tests, 2 new resolve-config tests, 1 new schema test