### PR TITLE
fix(core): use file:// URLs for command autoload imports

### DIFF
--- a/.changeset/fix-windows-autoload-paths.md
+++ b/.changeset/fix-windows-autoload-paths.md
@@ -1,0 +1,12 @@
+---
+'@kidd-cli/core': patch
+---
+
+fix(core): register subcommands on Windows by importing via `file://` URLs
+
+`autoload` previously passed absolute filesystem paths directly to `import()`.
+On Windows those paths use backslashes, which are not valid ESM specifiers,
+so every command import threw `ERR_UNSUPPORTED_ESM_URL_SCHEME` and was
+silently swallowed — leaving the CLI with no subcommands registered and
+yargs reporting "Unknown arguments" for any positional. Paths are now
+converted to `file://` URLs via `pathToFileURL` before import.

--- a/packages/core/src/autoload.test.ts
+++ b/packages/core/src/autoload.test.ts
@@ -11,6 +11,18 @@ vi.mock(import('node:fs/promises'), () => ({
   readdir: vi.fn(),
 }))
 
+const { mockPathToFileURL } = vi.hoisted(() => ({
+  mockPathToFileURL: vi.fn((p: string) => ({ href: p })),
+}))
+
+vi.mock(import('node:url'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    pathToFileURL: mockPathToFileURL,
+  }
+})
+
 function makeDirent(name: string, isFile: boolean): Dirent {
   return {
     isBlockDevice: () => false,
@@ -32,6 +44,7 @@ describe('autoload()', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
+    mockPathToFileURL.mockImplementation((p: string) => ({ href: p }))
   })
 
   it('should return empty CommandMap for empty directory', async () => {
@@ -261,6 +274,18 @@ describe('autoload()', () => {
 
     delete process.env.KIDD_DEBUG
     warnSpy.mockRestore()
+  })
+
+  it('should convert filesystem paths to file:// URLs before importing (Windows compat)', async () => {
+    mockedReaddir.mockResolvedValue([makeDirent('build.ts', true)] as unknown as Dirent[])
+
+    vi.doMock('/tmp/commands/build.ts', () => ({
+      default: withTag({ description: 'Build' }, 'Command'),
+    }))
+
+    await autoload({ dir: '/tmp/commands' })
+
+    expect(mockPathToFileURL).toHaveBeenCalledWith('/tmp/commands/build.ts')
   })
 
   it('should ignore non-ts/js files', async () => {

--- a/packages/core/src/autoload.ts
+++ b/packages/core/src/autoload.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { basename, extname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { isPlainObject, isString } from '@kidd-cli/utils/fp'
 import { hasTag, withTag } from '@kidd-cli/utils/tag'
@@ -131,20 +132,25 @@ function findIndexInEntries(entries: Dirent[]): Dirent | undefined {
 /**
  * Dynamically import a file and validate that its default export is a Command.
  *
+ * Converts the absolute filesystem path to a `file://` URL before passing to
+ * `import()` so resolution works on Windows (where backslash paths are not
+ * valid ESM specifiers).
+ *
  * @private
  * @param filePath - Absolute path to the file to import.
  * @returns The Command if valid, or undefined.
  */
 async function importCommand(filePath: string): Promise<Command | undefined> {
+  const specifier = pathToFileURL(filePath).href
   try {
-    const mod: unknown = await import(filePath)
+    const mod: unknown = await import(specifier)
     if (isCommandExport(mod)) {
       return mod.default
     }
     return undefined
   } catch (error: unknown) {
     if (isDebug()) {
-      console.warn(`[kidd] failed to import command from ${filePath}:`, error)
+      console.warn(`[kidd] failed to import command from ${specifier}:`, error)
     }
     return undefined
   }


### PR DESCRIPTION
## Summary

Fixes #179. On Windows, `kidd <subcommand>` printed "Unknown arguments" for every positional because the runtime autoloader silently failed to register any commands. The cause: `packages/core/src/autoload.ts` passed absolute filesystem paths straight to ESM `import()`. Node ESM rejects backslash-only paths and treats `C:` as an unknown URL scheme (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). The error was swallowed unless `KIDD_DEBUG=1`.

`path.join` was doing the right thing — building OS-native paths. The bug was the *next* step: those native paths aren't valid ESM specifiers. Fix: convert with `pathToFileURL(...).href` from `node:url` before `import()`, which produces `file:///...` URLs that resolve identically on macOS, Linux, and Windows.

## Changes

- `packages/core/src/autoload.ts` — wrap the path in `pathToFileURL(filePath).href` before the dynamic import; update the debug warning to log the URL form
- `packages/core/src/autoload.test.ts` — mock `node:url`'s `pathToFileURL` to passthrough so existing path-form `vi.doMock` keys still match (vitest can't intercept `file://` specifiers through helper indirection); add a regression test asserting `pathToFileURL` is invoked for command files
- `.changeset/fix-windows-autoload-paths.md` — `@kidd-cli/core` patch changeset

## Test plan

- [x] `pnpm check` (typecheck + lint + format) passes
- [x] `pnpm test` passes (1075 core tests, 17 tasks)
- [x] New regression test verifies `pathToFileURL` is called on the absolute path
- [ ] Manual verification on Windows 11: `kidd build --compile`, `kidd dev`, `kidd stories` all execute their handlers instead of yargs printing "Unknown arguments"

## Out of scope

There is a related concern in `packages/bundler/src/autoloader/generate-autoloader.ts` — it embeds native filesystem paths into generated `import` string literals, which would also break when *building* a CLI on Windows. That isn't the symptom reported in #179 (which is purely runtime command discovery in `@kidd-cli/cli`), so it's deliberately not included here. Happy to follow up in a separate PR if Windows testing surfaces it.