### PR TITLE
fix(cli): surface bundle errors via --verbose, accept DEBUG env var

### DIFF
--- a/.changeset/expose-bundle-errors-and-debug.md
+++ b/.changeset/expose-bundle-errors-and-debug.md
@@ -1,0 +1,6 @@
+---
+'@kidd-cli/cli': patch
+'@kidd-cli/core': patch
+---
+
+Forward `--verbose` from the `build` command into `bundler.build()` so the underlying tsdown error message is shown on bundle failure (previously only compile failures honored the flag). Also accept `DEBUG` as an alias for the `KIDD_DEBUG` environment variable; `KIDD_DEBUG` continues to take precedence when both are set.

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -315,6 +315,39 @@ describe('build command', () => {
     })
   })
 
+  describe('verbose forwarding', () => {
+    it('should pass verbose=true through to bundler.build', async () => {
+      const ctx = makeContext({ verbose: true })
+      setupBuildSuccess()
+
+      const mod = await import('./build.js')
+      await mod.default.handler!(ctx)
+
+      expect(mockBuild).toHaveBeenCalledWith({ verbose: true })
+    })
+
+    it('should pass verbose=undefined through to bundler.build by default', async () => {
+      const ctx = makeContext()
+      setupBuildSuccess()
+
+      const mod = await import('./build.js')
+      await mod.default.handler!(ctx)
+
+      expect(mockBuild).toHaveBeenCalledWith({ verbose: undefined })
+    })
+
+    it('should pass verbose=true through to bundler.compile', async () => {
+      const ctx = makeContext({ compile: true, verbose: true })
+      setupBuildSuccess()
+      setupCompileSuccess()
+
+      const mod = await import('./build.js')
+      await mod.default.handler!(ctx)
+
+      expect(mockCompile).toHaveBeenCalledWith({ verbose: true })
+    })
+  })
+
   describe('error handling', () => {
     it('should call fail when build returns an error', async () => {
       const ctx = makeContext()

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -16,7 +16,10 @@ const options = z.object({
   clean: z.boolean().optional().describe('Clean build artifacts before bundling (default: true)'),
   compile: z.boolean().optional().describe('Compile to standalone binaries after bundling'),
   targets: z.array(z.string()).optional().describe('Compile targets (implies --compile)'),
-  verbose: z.boolean().optional().describe('Show detailed error output on compile failure'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe('Show detailed error output on bundle or compile failure'),
 })
 
 type BuildArgs = z.infer<typeof options>
@@ -61,7 +64,7 @@ const buildCommand: Command = command({
 
     ctx.status.spinner.start('Bundling...')
 
-    const [buildError, buildOutput] = await bundler.build()
+    const [buildError, buildOutput] = await bundler.build({ verbose: ctx.args.verbose })
 
     if (buildError) {
       ctx.status.spinner.stop('Bundle failed')

--- a/packages/core/src/lib/debug.test.ts
+++ b/packages/core/src/lib/debug.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { isDebug } from './debug.js'
+
+const originalKidd = process.env.KIDD_DEBUG
+const originalDebug = process.env.DEBUG
+
+beforeEach(() => {
+  delete process.env.KIDD_DEBUG
+  delete process.env.DEBUG
+})
+
+afterEach(() => {
+  if (originalKidd === undefined) {
+    delete process.env.KIDD_DEBUG
+  } else {
+    process.env.KIDD_DEBUG = originalKidd
+  }
+
+  if (originalDebug === undefined) {
+    delete process.env.DEBUG
+  } else {
+    process.env.DEBUG = originalDebug
+  }
+})
+
+describe('isDebug()', () => {
+  it('should return false when neither env var is set', () => {
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should return true when KIDD_DEBUG is "true"', () => {
+    process.env.KIDD_DEBUG = 'true'
+    expect(isDebug()).toBeTruthy()
+  })
+
+  it('should return true when KIDD_DEBUG is "1"', () => {
+    process.env.KIDD_DEBUG = '1'
+    expect(isDebug()).toBeTruthy()
+  })
+
+  it('should return false when KIDD_DEBUG is "false"', () => {
+    process.env.KIDD_DEBUG = 'false'
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should return false when KIDD_DEBUG is "0"', () => {
+    process.env.KIDD_DEBUG = '0'
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should return true when DEBUG is "true"', () => {
+    process.env.DEBUG = 'true'
+    expect(isDebug()).toBeTruthy()
+  })
+
+  it('should return true when DEBUG is "1"', () => {
+    process.env.DEBUG = '1'
+    expect(isDebug()).toBeTruthy()
+  })
+
+  it('should return false when DEBUG is "false"', () => {
+    process.env.DEBUG = 'false'
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should prefer KIDD_DEBUG over DEBUG when both are set', () => {
+    process.env.KIDD_DEBUG = 'false'
+    process.env.DEBUG = 'true'
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should return false when KIDD_DEBUG is an empty string and DEBUG is unset', () => {
+    process.env.KIDD_DEBUG = ''
+    expect(isDebug()).toBeFalsy()
+  })
+
+  it('should return false for arbitrary truthy strings', () => {
+    process.env.KIDD_DEBUG = 'yes'
+    expect(isDebug()).toBeFalsy()
+  })
+})

--- a/packages/core/src/lib/debug.ts
+++ b/packages/core/src/lib/debug.ts
@@ -1,12 +1,15 @@
 /**
- * Check whether debug mode is enabled via the `KIDD_DEBUG` environment variable.
+ * Check whether debug mode is enabled via the `KIDD_DEBUG` or `DEBUG`
+ * environment variables.
+ *
+ * `KIDD_DEBUG` takes precedence; `DEBUG` is honored when `KIDD_DEBUG` is unset.
  *
  * Truthy values: `"true"`, `"1"`
  * Falsy values: `"false"`, `"0"`, `undefined`, `null`
  *
- * @returns `true` when `KIDD_DEBUG` is set to a truthy value.
+ * @returns `true` when `KIDD_DEBUG` or `DEBUG` is set to a truthy value.
  */
 export function isDebug(): boolean {
-  const value = process.env.KIDD_DEBUG
+  const value = process.env.KIDD_DEBUG ?? process.env.DEBUG
   return value === 'true' || value === '1'
 }


### PR DESCRIPTION
## Summary

- Forward `--verbose` from the `build` command into `bundler.build()` so the underlying tsdown error message is surfaced on bundle failure (previously only `compile` failures honored the flag).
- `isDebug()` now also honors the `DEBUG` env var. `KIDD_DEBUG` still takes precedence when both are set.

## Why

Diagnosing a Windows bundle failure surfaced two gaps:

1. `pnpm kidd build` reported only `tsdown build failed` — the real tsdown error was suppressed because the verbose flag never reached `bundler.build()` (only `bundler.compile()`).
2. Setting `KIDD_DEBUG=1` had no effect on the build path, and the more conventional `DEBUG` env var wasn't recognized at all.

## Notes

- `bundler.build` itself doesn't otherwise swallow errors — the thrown tsdown error is captured via `attemptAsync` and preserved as `.cause` on the returned Error. The verbose gate only controlled whether the message text was appended.
- Adjacent things spotted but **not** changed in this PR (potential follow-ups):
  - `clean()` silently ignores fs errors (resilient cleanup, not a failure path).
  - tsdown is invoked with `logLevel: 'silent'` for `build`; `watch` uses `'error'`. Could be raised to `'error'` in verbose mode if thin output persists.

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format)
- [x] `pnpm test` passes (1085 core + 158 cli, including new tests)
- [x] New `debug.test.ts` covers `KIDD_DEBUG`, `DEBUG`, precedence, empty-string, and unrecognized-string cases
- [x] New build command tests assert `verbose` forwards to both `bundler.build` and `bundler.compile`
- [ ] Spot-check on Windows: `pnpm kidd build --verbose` now shows tsdown error detail