### PR TITLE
feat: sidecar binary support (#170)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ vite.config.ts.timestamp-*
 
 # bun
 *.bun-build
+
+# joggr (gg planning artifacts — local only)
+.joggr/

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,12 @@
 export type { CompileTarget } from './utils/compile.js'
 export { defineConfig } from './define-config.js'
-export type { BuildOptions, CompileOptions, KiddConfig } from './types.js'
+export type {
+  BuildOptions,
+  CompileOptions,
+  KiddConfig,
+  SidecarChecksums,
+  SidecarConfig,
+  SidecarGithubSource,
+  SidecarPlatformMapping,
+  SidecarSource,
+} from './types.js'

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,6 +1,180 @@
 import type { CompileTarget } from './utils/compile.js'
 
 /**
+ * Source descriptor for a sidecar binary fetched from a GitHub release.
+ *
+ * Carries a `kind: 'github'` discriminator so {@link SidecarSource} can be
+ * widened into a true union (e.g. with `'url'`, `'npm'`, `'s3'` variants)
+ * in the future without breaking existing config files.
+ *
+ * @example
+ * ```ts
+ * const source: SidecarGithubSource = {
+ *   kind: 'github',
+ *   repo: 'astral-sh/ruff',
+ *   asset: 'ruff-{version}-{triple}.tar.gz',
+ * }
+ * ```
+ */
+export interface SidecarGithubSource {
+  /**
+   * Discriminator identifying the source backend as a GitHub release.
+   */
+  readonly kind: 'github'
+  /**
+   * `owner/name` slug of the GitHub repository hosting the release.
+   */
+  readonly repo: string
+  /**
+   * Asset name template. Supports `{version}` and `{triple}` placeholders
+   * that are interpolated per platform at resolution time.
+   */
+  readonly asset: string
+}
+
+/**
+ * Source descriptor for a sidecar binary download.
+ *
+ * Modeled as a discriminated union keyed on `kind` so additional sources
+ * (e.g. `'url'`, `'npm'`, `'s3'`) can be introduced in the future without
+ * breaking existing config files. v1 only supports
+ * {@link SidecarGithubSource}.
+ *
+ * @example
+ * ```ts
+ * const source: SidecarSource = {
+ *   kind: 'github',
+ *   repo: 'astral-sh/ruff',
+ *   asset: 'ruff-{version}-{triple}.tar.gz',
+ * }
+ * ```
+ */
+export type SidecarSource = SidecarGithubSource
+
+/**
+ * Platform-specific mapping for a sidecar asset.
+ *
+ * Provided as a shorthand `string` (the platform triple, used to interpolate
+ * the source's asset template) or an object form when a platform requires an
+ * asset-name override that diverges from the default template.
+ *
+ * @example
+ * ```ts
+ * // Shorthand: triple only
+ * const mac: SidecarPlatformMapping = 'aarch64-apple-darwin'
+ *
+ * // Object form: per-platform asset override
+ * const win: SidecarPlatformMapping = {
+ *   triple: 'x86_64-pc-windows-msvc',
+ *   asset: 'tool-{version}-windows.zip',
+ * }
+ * ```
+ */
+export type SidecarPlatformMapping =
+  | string
+  | {
+      /**
+       * Target triple used to interpolate `{triple}` in the asset template.
+       */
+      readonly triple: string
+      /**
+       * Optional asset-name override for this platform. When provided, it
+       * replaces the source's default `asset` template for this platform only.
+       */
+      readonly asset?: string
+    }
+
+/**
+ * Optional integrity checksums for sidecar downloads.
+ *
+ * Keys are platform target triples (or any opaque identifier the integrator
+ * controls) mapped to a hex-encoded digest string. Used to verify downloaded
+ * binaries before they are written to the cache.
+ *
+ * @example
+ * ```ts
+ * const checksums: SidecarChecksums = {
+ *   algorithm: 'sha256',
+ *   values: {
+ *     'aarch64-apple-darwin': 'd2c1...',
+ *     'x86_64-unknown-linux-gnu': '9b3a...',
+ *   },
+ * }
+ * ```
+ */
+export interface SidecarChecksums {
+  /**
+   * Hash algorithm used to produce the digests in `values`.
+   */
+  readonly algorithm: 'sha256' | 'sha512'
+  /**
+   * Map of platform triple (or other stable key) to hex-encoded digest.
+   */
+  readonly values: Readonly<Record<string, string>>
+}
+
+/**
+ * Configuration entry describing a single sidecar binary the CLI depends on.
+ *
+ * Sidecars are external executables fetched on demand and cached locally.
+ * Each entry declares an identity (`name`, `version`), how to obtain the
+ * artifact (`source`), which platforms are supported (`platforms`), and
+ * optional behavior tweaks (`lazy`, `checksums`).
+ *
+ * @example
+ * ```ts
+ * const ruff: SidecarConfig = {
+ *   name: 'ruff',
+ *   version: '0.6.9',
+ *   source: {
+ *     kind: 'github',
+ *     repo: 'astral-sh/ruff',
+ *     asset: 'ruff-{version}-{triple}.tar.gz',
+ *   },
+ *   platforms: {
+ *     'darwin-arm64': 'aarch64-apple-darwin',
+ *     'linux-x64': 'x86_64-unknown-linux-gnu',
+ *     'windows-x64': {
+ *       triple: 'x86_64-pc-windows-msvc',
+ *       asset: 'ruff-{version}-windows.zip',
+ *     },
+ *   },
+ *   lazy: true,
+ * }
+ * ```
+ */
+export interface SidecarConfig {
+  /**
+   * Stable identifier for the sidecar; used as the cache directory name and
+   * for log/diagnostic output.
+   */
+  readonly name: string
+  /**
+   * Version of the sidecar to install. Interpolated into the source's asset
+   * template as `{version}`.
+   */
+  readonly version: string
+  /**
+   * Source descriptor specifying where the binary is fetched from.
+   */
+  readonly source: SidecarSource
+  /**
+   * Per-platform mappings. Keys are {@link CompileTarget} values; only
+   * declared platforms are supported by this sidecar.
+   */
+  readonly platforms: Readonly<Partial<Record<CompileTarget, SidecarPlatformMapping>>>
+  /**
+   * When `true`, defer downloading the sidecar until first use rather than
+   * fetching eagerly during install. Default: `false`.
+   */
+  readonly lazy?: boolean
+  /**
+   * Optional integrity checksums applied to downloaded artifacts.
+   */
+  readonly checksums?: SidecarChecksums
+}
+
+/**
  * Build options passed to tsdown during `kidd build`.
  */
 export interface BuildOptions {
@@ -98,4 +272,11 @@ export interface KiddConfig {
    * Extra file globs to include in the bundle.
    */
   include?: string[]
+  /**
+   * Sidecar binaries the CLI depends on.
+   *
+   * Each entry declares an external executable that is fetched and cached
+   * for the user's platform. See {@link SidecarConfig} for the full shape.
+   */
+  readonly sidecars?: readonly SidecarConfig[]
 }

--- a/packages/config/src/utils/schema.test.ts
+++ b/packages/config/src/utils/schema.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { KiddConfigSchema, validateConfig } from './schema.js'
+import {
+  KiddConfigSchema,
+  SidecarChecksumsSchema,
+  SidecarPlatformMappingSchema,
+  SidecarSchema,
+  SidecarSourceSchema,
+  validateConfig,
+} from './schema.js'
 
 describe('KiddConfigSchema schema', () => {
   it('should accept an empty object', () => {
@@ -13,7 +20,12 @@ describe('KiddConfigSchema schema', () => {
     const result = KiddConfigSchema.safeParse({
       build: { external: ['pg'], minify: true, out: './dist', sourcemap: false, target: 'node20' },
       commands: './commands',
-      compile: { autoloadDotenv: true, name: 'my-cli', out: './bin', targets: ['linux-x64', 'darwin-arm64'] },
+      compile: {
+        autoloadDotenv: true,
+        name: 'my-cli',
+        out: './bin',
+        targets: ['linux-x64', 'darwin-arm64'],
+      },
       entry: './src/index.ts',
       include: ['assets/**'],
     })
@@ -59,6 +71,305 @@ describe('KiddConfigSchema schema', () => {
     const result = KiddConfigSchema.safeParse({ compile: false })
 
     expect(result.success).toBeTruthy()
+  })
+
+  it('should accept a full KiddConfig with sidecars populated', () => {
+    const result = KiddConfigSchema.safeParse({
+      entry: './src/index.ts',
+      sidecars: [
+        {
+          name: 'rg',
+          platforms: {
+            'darwin-arm64': 'aarch64-apple-darwin',
+            'linux-x64': 'x86_64-unknown-linux-gnu',
+          },
+          source: {
+            asset: 'rg-{version}-{triple}.tar.gz',
+            kind: 'github',
+            repo: 'BurntSushi/ripgrep',
+          },
+          version: '14.1.1',
+        },
+      ],
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept a KiddConfig without sidecars', () => {
+    const result = KiddConfigSchema.safeParse({ entry: './src/index.ts' })
+
+    expect(result.success).toBeTruthy()
+  })
+})
+
+describe('SidecarSourceSchema schema', () => {
+  it('should accept a github source', () => {
+    const result = SidecarSourceSchema.safeParse({
+      asset: 'ripgrep-{version}-{triple}.tar.gz',
+      kind: 'github',
+      repo: 'BurntSushi/ripgrep',
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should reject an unknown source kind', () => {
+    const result = SidecarSourceSchema.safeParse({
+      asset: 'foo.tar.gz',
+      kind: 'http',
+      repo: 'example/repo',
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a source missing repo', () => {
+    const result = SidecarSourceSchema.safeParse({
+      asset: 'foo.tar.gz',
+      kind: 'github',
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a source missing asset', () => {
+    const result = SidecarSourceSchema.safeParse({
+      kind: 'github',
+      repo: 'example/repo',
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject unknown keys in the source', () => {
+    const result = SidecarSourceSchema.safeParse({
+      asset: 'foo.tar.gz',
+      kind: 'github',
+      repo: 'example/repo',
+      unknown: true,
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+})
+
+describe('SidecarPlatformMappingSchema schema', () => {
+  it('should accept a plain string mapping', () => {
+    const result = SidecarPlatformMappingSchema.safeParse('aarch64-apple-darwin')
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept an object mapping with triple only', () => {
+    const result = SidecarPlatformMappingSchema.safeParse({ triple: 'aarch64-apple-darwin' })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept an object mapping with triple and asset override', () => {
+    const result = SidecarPlatformMappingSchema.safeParse({
+      asset: 'tool-{version}-windows.zip',
+      triple: 'x86_64-pc-windows-msvc',
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should reject an object mapping missing triple', () => {
+    const result = SidecarPlatformMappingSchema.safeParse({ asset: 'tool.zip' })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject an object mapping with unknown keys', () => {
+    const result = SidecarPlatformMappingSchema.safeParse({
+      extra: 'nope',
+      triple: 'aarch64-apple-darwin',
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a non-string non-object mapping', () => {
+    const result = SidecarPlatformMappingSchema.safeParse(42)
+
+    expect(result.success).toBeFalsy()
+  })
+})
+
+describe('SidecarChecksumsSchema schema', () => {
+  it('should accept a sha256 checksum bag', () => {
+    const result = SidecarChecksumsSchema.safeParse({
+      algorithm: 'sha256',
+      values: { 'aarch64-apple-darwin': 'abc123' },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept a sha512 checksum bag', () => {
+    const result = SidecarChecksumsSchema.safeParse({
+      algorithm: 'sha512',
+      values: {},
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should reject an unknown algorithm', () => {
+    const result = SidecarChecksumsSchema.safeParse({
+      algorithm: 'md5',
+      values: {},
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject missing values', () => {
+    const result = SidecarChecksumsSchema.safeParse({ algorithm: 'sha256' })
+
+    expect(result.success).toBeFalsy()
+  })
+})
+
+describe('SidecarSchema schema', () => {
+  const baseSidecar = {
+    name: 'rg',
+    platforms: {
+      'darwin-arm64': 'aarch64-apple-darwin',
+    },
+    source: {
+      asset: 'rg-{version}-{triple}.tar.gz',
+      kind: 'github',
+      repo: 'BurntSushi/ripgrep',
+    },
+    version: '14.1.1',
+  }
+
+  it('should accept a valid sidecar config', () => {
+    const result = SidecarSchema.safeParse(baseSidecar)
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept per-platform string mappings', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      platforms: {
+        'darwin-arm64': 'aarch64-apple-darwin',
+        'linux-x64': 'x86_64-unknown-linux-gnu',
+        'windows-x64': 'x86_64-pc-windows-msvc',
+      },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept per-platform object mappings with triple and asset override', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      platforms: {
+        'darwin-arm64': { triple: 'aarch64-apple-darwin' },
+        'windows-x64': {
+          asset: 'rg-{version}-windows.zip',
+          triple: 'x86_64-pc-windows-msvc',
+        },
+      },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept a mix of string and object platform mappings', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      platforms: {
+        'darwin-arm64': 'aarch64-apple-darwin',
+        'windows-x64': {
+          asset: 'rg-{version}-windows.zip',
+          triple: 'x86_64-pc-windows-msvc',
+        },
+      },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept optional lazy flag', () => {
+    const result = SidecarSchema.safeParse({ ...baseSidecar, lazy: true })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should accept optional checksums', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      checksums: {
+        algorithm: 'sha256',
+        values: { 'aarch64-apple-darwin': 'abc123' },
+      },
+    })
+
+    expect(result.success).toBeTruthy()
+  })
+
+  it('should reject a sidecar missing name', () => {
+    const result = SidecarSchema.safeParse({
+      platforms: baseSidecar.platforms,
+      source: baseSidecar.source,
+      version: baseSidecar.version,
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a sidecar missing version', () => {
+    const result = SidecarSchema.safeParse({
+      name: baseSidecar.name,
+      platforms: baseSidecar.platforms,
+      source: baseSidecar.source,
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a sidecar missing source', () => {
+    const result = SidecarSchema.safeParse({
+      name: baseSidecar.name,
+      platforms: baseSidecar.platforms,
+      version: baseSidecar.version,
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a sidecar with an invalid platform key', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      platforms: { 'darwin-amd64': 'aarch64-apple-darwin' },
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a sidecar with an invalid source.kind', () => {
+    const result = SidecarSchema.safeParse({
+      ...baseSidecar,
+      source: {
+        asset: 'foo.tar.gz',
+        kind: 'http',
+        repo: 'example/repo',
+      },
+    })
+
+    expect(result.success).toBeFalsy()
+  })
+
+  it('should reject a sidecar with unknown top-level keys', () => {
+    const result = SidecarSchema.safeParse({ ...baseSidecar, extra: true })
+
+    expect(result.success).toBeFalsy()
   })
 })
 

--- a/packages/config/src/utils/schema.ts
+++ b/packages/config/src/utils/schema.ts
@@ -2,7 +2,13 @@ import type { Result } from '@kidd-cli/utils'
 import { validate } from '@kidd-cli/utils/validate'
 import { z } from 'zod'
 
-import type { KiddConfig } from '../types.js'
+import type {
+  KiddConfig,
+  SidecarChecksums,
+  SidecarConfig,
+  SidecarPlatformMapping,
+  SidecarSource,
+} from '../types.js'
 import type { CompileTarget } from './compile.js'
 import { compileTargets } from './compile.js'
 
@@ -47,6 +53,112 @@ const CompileOptionsSchema = z
   .strict()
 
 /**
+ * Discriminated union of supported sidecar sources.
+ *
+ * v1 supports a single `kind: 'github'` source describing a GitHub release
+ * asset. The `kind` discriminator is included so future sources (`url`,
+ * `npm`, `s3`, etc.) can be added without a breaking change.
+ *
+ * @example
+ * ```ts
+ * SidecarSourceSchema.parse({
+ *   kind: 'github',
+ *   repo: 'BurntSushi/ripgrep',
+ *   asset: 'ripgrep-{version}-{triple}.tar.gz',
+ * })
+ * ```
+ */
+export const SidecarSourceSchema: z.ZodType<SidecarSource> = z
+  .object({
+    asset: z.string(),
+    kind: z.literal('github'),
+    repo: z.string(),
+  })
+  .strict()
+
+/**
+ * Per-platform mapping describing how to download a sidecar for a given target.
+ *
+ * Accepts either a plain string (the platform triple) or an object with an
+ * explicit `triple` and an optional per-platform `asset` override.
+ *
+ * @example
+ * ```ts
+ * // string form — the triple is interpolated into the source asset template
+ * SidecarPlatformMappingSchema.parse('aarch64-apple-darwin')
+ *
+ * // object form — overrides the asset template for this platform only
+ * SidecarPlatformMappingSchema.parse({
+ *   triple: 'x86_64-pc-windows-msvc',
+ *   asset: 'tool-{version}-windows.zip',
+ * })
+ * ```
+ */
+export const SidecarPlatformMappingSchema: z.ZodType<SidecarPlatformMapping> = z.union([
+  z.string(),
+  z
+    .object({
+      asset: z.string().optional(),
+      triple: z.string(),
+    })
+    .strict(),
+])
+
+/**
+ * Optional integrity checksums for sidecar downloads.
+ *
+ * Pairs a hash `algorithm` with a `values` map keyed by platform triple (or
+ * any opaque identifier the integrator controls) mapped to a hex-encoded digest.
+ *
+ * @example
+ * ```ts
+ * SidecarChecksumsSchema.parse({
+ *   algorithm: 'sha256',
+ *   values: {
+ *     'aarch64-apple-darwin': 'd2c1...',
+ *     'x86_64-unknown-linux-gnu': '9b3a...',
+ *   },
+ * })
+ * ```
+ */
+export const SidecarChecksumsSchema: z.ZodType<SidecarChecksums> = z
+  .object({
+    algorithm: z.enum(['sha256', 'sha512']),
+    values: z.record(z.string(), z.string()),
+  })
+  .strict()
+
+/**
+ * Validates the full {@link SidecarConfig} shape: `name`, `version`, `source`,
+ * `platforms`, and the optional `lazy` and `checksums` fields. Uses `.strict()`
+ * to reject unknown keys so configuration typos surface as validation errors.
+ *
+ * Platform keys are restricted to the {@link CompileTarget} union via
+ * {@link CompileTargetSchema}, so misspelled platforms (e.g. `darwin-amd64`)
+ * fail validation rather than being silently ignored.
+ *
+ * @example
+ * ```ts
+ * SidecarSchema.parse({
+ *   name: 'rg',
+ *   version: '14.1.1',
+ *   source: { kind: 'github', repo: 'BurntSushi/ripgrep', asset: 'rg-{version}-{triple}.tar.gz' },
+ *   platforms: { 'darwin-arm64': 'aarch64-apple-darwin' },
+ * })
+ * ```
+ */
+export const SidecarSchema: z.ZodType<SidecarConfig> = z
+  .object({
+    checksums: SidecarChecksumsSchema.optional(),
+    lazy: z.boolean().optional(),
+    name: z.string(),
+    platforms: z.partialRecord(CompileTargetSchema, SidecarPlatformMappingSchema),
+    source: SidecarSourceSchema,
+    version: z.string(),
+  })
+  .strict()
+
+/**
  * Zod schema validating the {@link KiddConfig} shape.
  */
 export const KiddConfigSchema: z.ZodType<KiddConfig> = z
@@ -56,6 +168,7 @@ export const KiddConfigSchema: z.ZodType<KiddConfig> = z
     compile: z.union([z.boolean(), CompileOptionsSchema]).optional(),
     entry: z.string().optional(),
     include: z.array(z.string()).optional(),
+    sidecars: z.array(SidecarSchema).optional(),
   })
   .strict()
 

--- a/packages/utils/src/fp/index.ts
+++ b/packages/utils/src/fp/index.ts
@@ -1,4 +1,6 @@
 export * from 'es-toolkit'
 export { match, P } from 'ts-pattern'
 export * from './result.js'
+export { retry } from './retry.js'
+export type { RetryOptions } from './retry.js'
 export * from './transform.js'

--- a/packages/utils/src/fp/retry.test.ts
+++ b/packages/utils/src/fp/retry.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { err, ok } from './result.js'
+import type { Result } from './result.js'
+import { retry } from './retry.js'
+
+describe('retry()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('should return ok on the first attempt without scheduling any timer', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fn = vi.fn(async (): Promise<Result<string>> => ok('first'))
+
+    const result = await retry({ attempts: 3, baseMs: 500, fn })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+    expect(result).toEqual([null, 'first'])
+  })
+
+  it('should return the first ok result and stop calling fn', async () => {
+    const fn = vi
+      .fn<() => Promise<Result<number>>>()
+      .mockResolvedValueOnce(err(new Error('fail-1')))
+      .mockResolvedValueOnce(ok(42))
+      .mockResolvedValueOnce(ok(99))
+
+    const promise = retry({ attempts: 3, baseMs: 500, fn })
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    const [error, value] = await promise
+
+    expect(error).toBeNull()
+    expect(value).toBe(42)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should follow baseMs * 2 ^ (attempt - 1) backoff schedule', async () => {
+    const fn = vi
+      .fn<() => Promise<Result<string>>>()
+      .mockResolvedValueOnce(err(new Error('attempt-1')))
+      .mockResolvedValueOnce(err(new Error('attempt-2')))
+      .mockResolvedValueOnce(ok('attempt-3'))
+
+    const promise = retry({ attempts: 3, baseMs: 500, fn })
+
+    // Allow the first attempt's microtasks to flush.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Just before the first backoff (500ms) elapses, no second attempt yet.
+    await vi.advanceTimersByTimeAsync(499)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // After the full 500ms, the second attempt fires.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+
+    // Just before the second backoff (1000ms) elapses, no third attempt yet.
+    await vi.advanceTimersByTimeAsync(999)
+    expect(fn).toHaveBeenCalledTimes(2)
+
+    // After the full 1000ms, the third attempt fires and succeeds.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fn).toHaveBeenCalledTimes(3)
+
+    const [error, value] = await promise
+    expect(error).toBeNull()
+    expect(value).toBe('attempt-3')
+  })
+
+  it('should record exact setTimeout delays of 500ms then 1000ms for attempts=3, baseMs=500', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fn = vi
+      .fn<() => Promise<Result<string>>>()
+      .mockResolvedValueOnce(err(new Error('1')))
+      .mockResolvedValueOnce(err(new Error('2')))
+      .mockResolvedValueOnce(ok('done'))
+
+    const promise = retry({ attempts: 3, baseMs: 500, fn })
+    await vi.advanceTimersByTimeAsync(2000)
+    await promise
+
+    const delays = setTimeoutSpy.mock.calls.map((call) => call[1])
+    expect(delays).toEqual([500, 1000])
+  })
+
+  it('should return the last err result after exhausting attempts', async () => {
+    const errors = [new Error('first'), new Error('second'), new Error('final')]
+    const fn = vi
+      .fn<() => Promise<Result<string>>>()
+      .mockResolvedValueOnce(err(errors[0]))
+      .mockResolvedValueOnce(err(errors[1]))
+      .mockResolvedValueOnce(err(errors[2]))
+
+    const promise = retry({ attempts: 3, baseMs: 100, fn })
+    await vi.advanceTimersByTimeAsync(1000)
+    const [error, value] = await promise
+
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(error).toBe(errors[2])
+    expect(value).toBeNull()
+  })
+
+  it('should not throw when fn always fails — returns last err instead', async () => {
+    const fn = vi.fn(async (): Promise<Result<string>> => err(new Error('always fails')))
+
+    const promise = retry({ attempts: 4, baseMs: 10, fn })
+    await vi.advanceTimersByTimeAsync(1000)
+
+    await expect(promise).resolves.toBeDefined()
+    const [error] = await promise
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe('always fails')
+    expect(fn).toHaveBeenCalledTimes(4)
+  })
+
+  it('should make exactly one call when attempts=1 (no retries)', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fn = vi.fn(async (): Promise<Result<string>> => err(new Error('one and done')))
+
+    const result = await retry({ attempts: 1, baseMs: 500, fn })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+    expect(result[0]?.message).toBe('one and done')
+  })
+
+  it('should propagate domain-specific error types through the Result tuple', async () => {
+    interface DomainError {
+      readonly type: 'network' | 'timeout'
+      readonly message: string
+    }
+    const domainError: DomainError = { message: 'connection refused', type: 'network' }
+    const fn = vi
+      .fn<() => Promise<Result<number, DomainError>>>()
+      .mockResolvedValue([domainError, null] as const)
+
+    const promise = retry<number, DomainError>({ attempts: 2, baseMs: 50, fn })
+    await vi.advanceTimersByTimeAsync(100)
+    const [error, value] = await promise
+
+    expect(error).toEqual(domainError)
+    expect(value).toBeNull()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/utils/src/fp/retry.ts
+++ b/packages/utils/src/fp/retry.ts
@@ -1,0 +1,115 @@
+import type { Result } from './result.js'
+
+/**
+ * Options for {@link retry}.
+ *
+ * @template TValue - The success value type returned by `fn`.
+ * @template TError - The error type returned by `fn`. Defaults to `Error`.
+ */
+export interface RetryOptions<TValue, TError = Error> {
+  /**
+   * Maximum number of attempts (including the first call). Must be >= 1.
+   * Values < 1 are coerced to 1.
+   */
+  readonly attempts: number
+  /**
+   * Base delay (in milliseconds) used to compute exponential backoff between
+   * retries. Delay before attempt N (1-indexed) is `baseMs * 2 ^ (N - 1)`,
+   * applied only when retrying after a failure (no delay before the first
+   * attempt). Values < 0 are coerced to 0.
+   */
+  readonly baseMs: number
+  /**
+   * The async operation to execute. Must return a `Result` tuple — never
+   * throw. The first `ok` result short-circuits the loop; otherwise the last
+   * `err` is returned after exhausting `attempts`.
+   */
+  readonly fn: () => Promise<Result<TValue, TError>>
+}
+
+/**
+ * Retry an async `Result`-returning operation with exponential backoff.
+ *
+ * Calls `fn` up to `attempts` times, returning the first `ok` result. On
+ * exhaustion, returns the last `err` — never throws. Backoff between retries
+ * follows `baseMs * 2 ^ (attempt - 1)`:
+ *
+ * | Attempt | Delay before this attempt |
+ * | ------- | ------------------------- |
+ * | 1       | 0 (immediate)             |
+ * | 2       | `baseMs`                  |
+ * | 3       | `baseMs * 2`              |
+ * | 4       | `baseMs * 4`              |
+ *
+ * A successful first attempt skips all retries and never schedules a timer.
+ *
+ * @param options - Retry configuration.
+ * @param options.attempts - Maximum number of attempts (>= 1).
+ * @param options.baseMs - Base delay in milliseconds for exponential backoff.
+ * @param options.fn - Async `Result`-returning operation to retry.
+ * @returns A `Result` tuple — the first success, or the last failure on
+ *   exhaustion. Never rejects.
+ */
+export async function retry<TValue, TError = Error>({
+  attempts,
+  baseMs,
+  fn,
+}: RetryOptions<TValue, TError>): Promise<Result<TValue, TError>> {
+  const safeAttempts = Math.max(1, attempts)
+  const safeBaseMs = Math.max(0, baseMs)
+  return runAttempt({ attempt: 1, baseMs: safeBaseMs, fn, maxAttempts: safeAttempts })
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single retry attempt and recurse into the next attempt on failure.
+ *
+ * Implemented via tail recursion to avoid `let` / loops while preserving the
+ * exponential-backoff schedule. Returns the first success or the last failure
+ * when attempts are exhausted.
+ *
+ * @param params - Attempt parameters.
+ * @param params.attempt - The current 1-indexed attempt number.
+ * @param params.baseMs - Base delay in milliseconds for exponential backoff.
+ * @param params.fn - The async `Result`-returning operation under retry.
+ * @param params.maxAttempts - Total number of attempts allowed.
+ * @returns The success result, or the last error on exhaustion.
+ *
+ * @private
+ */
+async function runAttempt<TValue, TError>(params: {
+  readonly attempt: number
+  readonly baseMs: number
+  readonly fn: () => Promise<Result<TValue, TError>>
+  readonly maxAttempts: number
+}): Promise<Result<TValue, TError>> {
+  const { attempt, baseMs, fn, maxAttempts } = params
+  const result = await fn()
+  const [error] = result
+  if (!error) {
+    return result
+  }
+  if (attempt >= maxAttempts) {
+    return result
+  }
+  const delayMs = baseMs * 2 ** (attempt - 1)
+  await delay(delayMs)
+  return runAttempt({ attempt: attempt + 1, baseMs, fn, maxAttempts })
+}
+
+/**
+ * Resolve after `ms` milliseconds via `setTimeout`.
+ *
+ * Promise wrapper to keep `runAttempt` free of imperative timer plumbing.
+ *
+ * @param ms - Delay in milliseconds.
+ * @returns A promise that resolves once the timer fires.
+ *
+ * @private
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/packages/utils/src/node/index.ts
+++ b/packages/utils/src/node/index.ts
@@ -1,3 +1,15 @@
 export * as fs from './fs.js'
 export * as path from './path.js'
+export {
+  ARCH_MAP,
+  PLATFORM_MAP,
+  binExt,
+  binName,
+  getPlatformDir,
+  getPlatformTriple,
+  isLinux,
+  isMacOS,
+  isWindows,
+} from './platform.js'
+export type { CompileTarget } from './platform.js'
 export * as process from './process.js'

--- a/packages/utils/src/node/platform.test.ts
+++ b/packages/utils/src/node/platform.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReadFileSync = vi.hoisted(() => vi.fn())
+
+vi.mock(import('node:fs'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    readFileSync: mockReadFileSync,
+  }
+})
+
+const {
+  ARCH_MAP,
+  PLATFORM_MAP,
+  binExt,
+  binName,
+  getPlatformDir,
+  getPlatformTriple,
+  isLinux,
+  isMacOS,
+  isWindows,
+} = await import('./platform.js')
+
+interface ProcessMock {
+  readonly platform: string
+  readonly arch: string
+}
+
+function setProcess(values: ProcessMock): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: values.platform })
+  Object.defineProperty(process, 'arch', { configurable: true, value: values.arch })
+}
+
+const originalPlatform = process.platform
+const originalArch = process.arch
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  Object.defineProperty(process, 'arch', { configurable: true, value: originalArch })
+  vi.clearAllMocks()
+})
+
+describe('PLATFORM_MAP', () => {
+  it('should map win32 to windows', () => {
+    expect(PLATFORM_MAP.win32).toBe('windows')
+  })
+
+  it('should map cygwin to windows', () => {
+    expect(PLATFORM_MAP.cygwin).toBe('windows')
+  })
+
+  it('should map darwin to darwin', () => {
+    expect(PLATFORM_MAP.darwin).toBe('darwin')
+  })
+
+  it('should map linux to linux', () => {
+    expect(PLATFORM_MAP.linux).toBe('linux')
+  })
+})
+
+describe('ARCH_MAP', () => {
+  it('should map x64 to x64', () => {
+    expect(ARCH_MAP.x64).toBe('x64')
+  })
+
+  it('should map arm64 to arm64', () => {
+    expect(ARCH_MAP.arm64).toBe('arm64')
+  })
+})
+
+describe('platform triple', () => {
+  beforeEach(() => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+  })
+
+  it('should return darwin-arm64 on Apple Silicon macOS', () => {
+    setProcess({ arch: 'arm64', platform: 'darwin' })
+    expect(getPlatformTriple()).toBe('darwin-arm64')
+  })
+
+  it('should return darwin-x64 on Intel macOS', () => {
+    setProcess({ arch: 'x64', platform: 'darwin' })
+    expect(getPlatformTriple()).toBe('darwin-x64')
+  })
+
+  it('should return linux-arm64 on ARM Linux', () => {
+    setProcess({ arch: 'arm64', platform: 'linux' })
+    expect(getPlatformTriple()).toBe('linux-arm64')
+  })
+
+  it('should return linux-x64 on glibc Linux when /etc/os-release is unreadable', () => {
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(getPlatformTriple()).toBe('linux-x64')
+  })
+
+  it('should return linux-x64 on glibc Linux when /etc/os-release lacks ID=alpine', () => {
+    mockReadFileSync.mockReturnValueOnce('ID=ubuntu\nVERSION_ID="22.04"\n')
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(getPlatformTriple()).toBe('linux-x64')
+  })
+
+  it('should return linux-x64-musl on Alpine Linux', () => {
+    mockReadFileSync.mockReturnValueOnce('NAME="Alpine Linux"\nID=alpine\nVERSION_ID=3.19\n')
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(getPlatformTriple()).toBe('linux-x64-musl')
+  })
+
+  it('should return windows-arm64 on ARM Windows', () => {
+    setProcess({ arch: 'arm64', platform: 'win32' })
+    expect(getPlatformTriple()).toBe('windows-arm64')
+  })
+
+  it('should return windows-x64 on Intel Windows', () => {
+    setProcess({ arch: 'x64', platform: 'win32' })
+    expect(getPlatformTriple()).toBe('windows-x64')
+  })
+
+  it('should treat cygwin as windows', () => {
+    setProcess({ arch: 'x64', platform: 'cygwin' })
+    expect(getPlatformTriple()).toBe('windows-x64')
+  })
+
+  it('should fall back to linux-x64 on unknown platforms', () => {
+    setProcess({ arch: 'mips', platform: 'aix' })
+    expect(getPlatformTriple()).toBe('linux-x64')
+  })
+})
+
+describe('platform directory', () => {
+  beforeEach(() => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+  })
+
+  it('should join the platforms directory using path.join (POSIX)', () => {
+    setProcess({ arch: 'arm64', platform: 'darwin' })
+    expect(getPlatformDir('/usr/local/bin/my-cli')).toBe('/usr/local/bin/platforms/darwin-arm64')
+  })
+
+  it('should resolve relative to the binary parent directory', () => {
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(getPlatformDir('/opt/tool/bin/run')).toBe('/opt/tool/bin/platforms/linux-x64')
+  })
+})
+
+describe('binary name suffix', () => {
+  it('should leave the name unchanged on POSIX', () => {
+    setProcess({ arch: 'arm64', platform: 'darwin' })
+    expect(binName('rg')).toBe('rg')
+  })
+
+  it('should append .exe on Windows', () => {
+    setProcess({ arch: 'x64', platform: 'win32' })
+    expect(binName('rg')).toBe('rg.exe')
+  })
+
+  it('should append .exe on cygwin', () => {
+    setProcess({ arch: 'x64', platform: 'cygwin' })
+    expect(binName('rg')).toBe('rg.exe')
+  })
+})
+
+describe('binary extension', () => {
+  it('should return empty string on POSIX', () => {
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(binExt()).toBe('')
+  })
+
+  it('should return .exe on Windows', () => {
+    setProcess({ arch: 'x64', platform: 'win32' })
+    expect(binExt()).toBe('.exe')
+  })
+})
+
+describe('platform predicates', () => {
+  it('should report Windows correctly', () => {
+    setProcess({ arch: 'x64', platform: 'win32' })
+    expect(isWindows()).toBeTruthy()
+    expect(isMacOS()).toBeFalsy()
+    expect(isLinux()).toBeFalsy()
+  })
+
+  it('should report macOS correctly', () => {
+    setProcess({ arch: 'arm64', platform: 'darwin' })
+    expect(isMacOS()).toBeTruthy()
+    expect(isWindows()).toBeFalsy()
+    expect(isLinux()).toBeFalsy()
+  })
+
+  it('should report Linux correctly', () => {
+    setProcess({ arch: 'x64', platform: 'linux' })
+    expect(isLinux()).toBeTruthy()
+    expect(isWindows()).toBeFalsy()
+    expect(isMacOS()).toBeFalsy()
+  })
+
+  it('should treat cygwin as Windows', () => {
+    setProcess({ arch: 'x64', platform: 'cygwin' })
+    expect(isWindows()).toBeTruthy()
+  })
+})

--- a/packages/utils/src/node/platform.ts
+++ b/packages/utils/src/node/platform.ts
@@ -1,0 +1,229 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+import { attempt } from 'es-toolkit'
+import { match } from 'ts-pattern'
+
+/**
+ * Supported cross-compilation targets for sidecar binaries.
+ *
+ * Mirrors the `CompileTarget` union exported from `@kidd-cli/config`. Defined
+ * locally here to avoid a circular dependency between `@kidd-cli/utils` and
+ * `@kidd-cli/config` (config already depends on utils). Both sources must stay
+ * in sync — see `packages/config/src/utils/compile.ts` for the canonical list.
+ */
+export type CompileTarget =
+  | 'darwin-arm64'
+  | 'darwin-x64'
+  | 'linux-arm64'
+  | 'linux-x64'
+  | 'linux-x64-musl'
+  | 'windows-arm64'
+  | 'windows-x64'
+
+/**
+ * Map from Node.js `process.platform` values to compile-target OS prefixes.
+ *
+ * Frozen at module load. Callers should treat this as readonly.
+ *
+ * @example
+ * ```ts
+ * const os = PLATFORM_MAP[process.platform]
+ * // 'darwin' on macOS, 'linux' on Linux, 'windows' on Windows
+ * ```
+ */
+export const PLATFORM_MAP: Readonly<Record<NodeJS.Platform, string>> = {
+  aix: 'aix',
+  android: 'android',
+  cygwin: 'windows',
+  darwin: 'darwin',
+  freebsd: 'freebsd',
+  haiku: 'haiku',
+  linux: 'linux',
+  netbsd: 'netbsd',
+  openbsd: 'openbsd',
+  sunos: 'sunos',
+  win32: 'windows',
+}
+
+/**
+ * Map from Node.js `process.arch` values to compile-target architecture suffixes.
+ *
+ * Frozen at module load. Callers should treat this as readonly.
+ *
+ * @example
+ * ```ts
+ * const arch = ARCH_MAP[process.arch]
+ * // 'arm64' on Apple Silicon, 'x64' on Intel
+ * ```
+ */
+export const ARCH_MAP: Readonly<Record<string, string>> = {
+  arm64: 'arm64',
+  x64: 'x64',
+}
+
+/**
+ * Detect the host platform and return its compile-target triple.
+ *
+ * Combines `process.platform` and `process.arch` into a {@link CompileTarget}
+ * such as `darwin-arm64`. On Linux x64, also probes `/etc/os-release` for the
+ * `ID=alpine` marker — Alpine ships musl libc, which requires a separate
+ * `linux-x64-musl` binary. Any read or parse failure falls back to
+ * `linux-x64` (glibc).
+ *
+ * Unknown platform/arch combinations fall back to `linux-x64`. Callers
+ * targeting non-canonical hosts should validate before launching a sidecar.
+ *
+ * @returns The {@link CompileTarget} matching the current host.
+ * @example
+ * ```ts
+ * const target = getPlatformTriple()
+ * // 'darwin-arm64' on Apple Silicon macOS
+ * // 'linux-x64-musl' on Alpine Linux
+ * ```
+ */
+export function getPlatformTriple(): CompileTarget {
+  const os = PLATFORM_MAP[process.platform] ?? process.platform
+  const arch = ARCH_MAP[process.arch] ?? process.arch
+
+  return match([os, arch] as const)
+    .returnType<CompileTarget>()
+    .with(['darwin', 'arm64'], () => 'darwin-arm64')
+    .with(['darwin', 'x64'], () => 'darwin-x64')
+    .with(['linux', 'arm64'], () => 'linux-arm64')
+    .with(['linux', 'x64'], () =>
+      match(isMuslLinux())
+        .returnType<CompileTarget>()
+        .with(true, () => 'linux-x64-musl')
+        .with(false, () => 'linux-x64')
+        .exhaustive()
+    )
+    .with(['windows', 'arm64'], () => 'windows-arm64')
+    .with(['windows', 'x64'], () => 'windows-x64')
+    .otherwise(() => 'linux-x64')
+}
+
+/**
+ * Resolve the absolute directory that holds a sidecar binary for the host.
+ *
+ * Given the path of an executable, returns its sibling
+ * `platforms/<os>-<arch>/` directory. Uses `path.join` so the separator is
+ * native (forward slashes on POSIX, backslashes on Windows) and never
+ * hardcoded.
+ *
+ * @param execPath - Absolute path to the calling executable.
+ * @returns The absolute path of the per-platform binary directory.
+ * @example
+ * ```ts
+ * // POSIX, on darwin-arm64:
+ * getPlatformDir('/usr/local/bin/my-cli')
+ * // → '/usr/local/bin/platforms/darwin-arm64'
+ * ```
+ */
+export function getPlatformDir(execPath: string): string {
+  return join(dirname(execPath), 'platforms', getPlatformTriple())
+}
+
+/**
+ * Append the platform-specific executable extension to a binary name.
+ *
+ * On Windows, executables require a `.exe` suffix; on POSIX systems they
+ * have no extension. Pass an unsuffixed base name and let this helper add
+ * the extension if needed.
+ *
+ * @param name - Base binary name without extension.
+ * @returns The name with `.exe` appended on Windows, unchanged elsewhere.
+ * @example
+ * ```ts
+ * binName('rg') // 'rg' on POSIX, 'rg.exe' on Windows
+ * ```
+ */
+export function binName(name: string): string {
+  return `${name}${binExt()}`
+}
+
+/**
+ * Return the platform-specific executable extension.
+ *
+ * `.exe` on Windows, an empty string on every other platform.
+ *
+ * @returns `.exe` on Windows, `''` elsewhere.
+ * @example
+ * ```ts
+ * const suffix = binExt() // '.exe' on Windows
+ * ```
+ */
+export function binExt(): '.exe' | '' {
+  return match(isWindows())
+    .returnType<'.exe' | ''>()
+    .with(true, () => '.exe')
+    .with(false, () => '')
+    .exhaustive()
+}
+
+/**
+ * Whether the host is Windows.
+ *
+ * Tracks both `win32` and `cygwin` values of `process.platform`.
+ *
+ * @returns `true` when running on Windows.
+ * @example
+ * ```ts
+ * if (isWindows()) {
+ *   // …
+ * }
+ * ```
+ */
+export function isWindows(): boolean {
+  return process.platform === 'win32' || process.platform === 'cygwin'
+}
+
+/**
+ * Whether the host is macOS.
+ *
+ * @returns `true` when `process.platform === 'darwin'`.
+ * @example
+ * ```ts
+ * if (isMacOS()) {
+ *   // …
+ * }
+ * ```
+ */
+export function isMacOS(): boolean {
+  return process.platform === 'darwin'
+}
+
+/**
+ * Whether the host is Linux.
+ *
+ * @returns `true` when `process.platform === 'linux'`.
+ * @example
+ * ```ts
+ * if (isLinux()) {
+ *   // …
+ * }
+ * ```
+ */
+export function isLinux(): boolean {
+  return process.platform === 'linux'
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether the running Linux distribution uses musl libc.
+ *
+ * Reads `/etc/os-release` and looks for `ID=alpine` (the canonical musl
+ * distribution). Any read or parse failure resolves to `false` — callers
+ * should default to glibc when uncertain.
+ *
+ * @private
+ * @returns `true` when the host appears to be Alpine Linux.
+ */
+function isMuslLinux(): boolean {
+  const [error, contents] = attempt<string, Error>(() => readFileSync('/etc/os-release', 'utf8'))
+  if (error || contents === null) {
+    return false
+  }
+  return /^ID=alpine\s*$/m.test(contents)
+}


### PR DESCRIPTION
## Summary

Draft PR tracking [issue #170](https://github.com/joggrdocs/kidd/issues/170) — sidecar binary support for kidd-powered CLIs.

This PR currently contains only a `.gitignore` update. Implementation will land in subsequent commits following the plan tracked locally in `.joggr/.gg/tasks/sidecar-binary-support/`.

## Approach

**Clean-slate redesign with config-as-code** (selected over the agent-recommended Hybrid). Key design points:

- Zod-first `sidecars` schema in `@kidd-cli/config`; type-inference flows into runtime
- Single-stage TS-native pipeline: download → verify → extract → place straight into `platforms/{os-arch}/` (no `dist/vendors/` indirection)
- `kidd-sidecars.json` manifest emitted alongside platform binaries — `sidecar()` runtime and lazy-download share one typed source of truth
- Public API is `sidecar()` (Shape B): `{ exec(name, args), path(name) }` — bare-verb export matching `command()`, `cli()`, `middleware()`
- Stdlib-only spawn (`node:child_process`); TS-native extraction (`tar` + `extract-zip`); no `execa`, no bash scripts
- npm `@cli-{platform}` optional-dep packages generated for non-compiled distribution
- Per-sidecar `lazy: true` defers download to first runtime use, with retry-with-backoff
- macOS `xattr -cr` + ad-hoc codesign on darwin-* outputs (graceful skip when host is non-darwin)

## Plan

5 phases, 19 tasks:

| Phase | Tasks | Scope |
|---|---|---|
| 1 — Foundation | 4 | Config types + Zod schemas, platform helpers, retry helper |
| 2 — Bundler pipeline | 8 | Types, download, extract, place, macOS, manifest, orchestrate, wire-up |
| 3 — Runtime resolver | 3 | `sidecar()` factory, lazy runtime, core export wiring |
| 4 — Distribution + CLI | 2 | npm `@cli-{platform}` staging, wire into `kidd build` |
| 5 — Example, integration, docs | 3 | `examples/sidecar-demo`, integration test, concept/guide/reference docs |

## Acceptance criteria (from #170)

- [ ] `sidecars` config validates via Zod; existing configs unchanged
- [ ] Platform helpers exported from `@kidd-cli/utils` with explicit return types + tests
- [ ] Bundler downloads + extracts `.tar.gz`/`.zip` via TS-native libs (no bash); writes to `platforms/{os-arch}/`
- [ ] macOS quarantine strip + ad-hoc codesign on darwin outputs; `executableFiles` on platform packages
- [ ] `@cli-{platform}` npm optional-dep packages generated
- [ ] `sidecar()` exported from `@kidd-cli/core`; `exec()` returns `{ stdout, stderr, exitCode }` via stdlib
- [ ] Lookup-miss throws actionable error; lazy mode supports retry + Result tuples
- [ ] Optional checksum verification rejects mismatches at build time
- [ ] Unit tests + at least one real-download integration test
- [ ] `examples/sidecar-demo` end-to-end working
- [ ] `bun build --compile` succeeds for all 7 targets with sidecars
- [ ] `docs/concepts/sidecars.md` + `docs/guides/add-a-sidecar.md` + `docs/reference/sidecar.md`
- [ ] `pnpm check` and `pnpm test` green; `isolatedDeclarations` passes

## Test plan

- [ ] Unit tests pass for all new modules (`pnpm test`)
- [ ] Type checking + linting green (`pnpm check`)
- [ ] Integration test downloads `rg` v14.1.1 and verifies end-to-end on host platform
- [ ] CI integration matrix passes on macOS ARM/Intel, Linux x64, Windows x64
- [ ] `examples/sidecar-demo` builds and runs locally

Closes #170