### PR TITLE
docs: fix documentation site and use maltty.sh everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://www.npmjs.com/package/maltty"><img src="https://img.shields.io/npm/v/maltty" alt="npm version" /></a>
 <a href="https://github.com/thebytefarm/maltty/blob/main/LICENSE"><img src="https://img.shields.io/github/license/thebytefarm/maltty" alt="License" /></a>
 
-<a href="https://maltty.dev">📖 Documentation</a> &nbsp;&nbsp;&nbsp;·&nbsp;&nbsp;&nbsp; <a href="https://github.com/thebytefarm/maltty/issues">🐛 Issues</a>
+<a href="https://maltty.sh">📖 Documentation</a> &nbsp;&nbsp;&nbsp;·&nbsp;&nbsp;&nbsp; <a href="https://github.com/thebytefarm/maltty/issues">🐛 Issues</a>
 
 </div>
 


### PR DESCRIPTION
## Summary

The documentation site at **maltty.sh** wasn't showing. Root cause was infrastructure, not content — plus a stale domain reference in the README.

## What was broken

1. **GitHub Pages was never enabled** on the repo, so the `Configure Pages` step in `docs.yml` failed on every run (`Get Pages site failed... verify that the repository has Pages enabled`). The docs built fine but never deployed.
2. **No custom domain** was configured in Pages.
3. **DNS** for `maltty.sh` pointed at Namecheap's parking IP instead of GitHub Pages.
4. **README** linked to the retired `maltty.dev` host.

## Fixes

| Where | Change |
|---|---|
| GitHub Pages (repo settings) | Enabled with `build_type: workflow` |
| GitHub Pages (repo settings) | Custom domain set to `maltty.sh` |
| Namecheap DNS | Apex `A` records repointed to `185.199.108-111.153` |
| `README.md` | Documentation link `maltty.dev` -> `maltty.sh` (this diff) |

Docs now deploy green end-to-end and `maltty.sh` resolves to GitHub Pages.

## Note

The repo-side infra changes (Pages enablement, custom domain, DNS) were applied out-of-band via the GitHub and Namecheap APIs — they aren't code and can't live in this diff. This PR carries the one in-repo change: the README domain fix. Repo-wide domain sweep is otherwise clean (only historical `kidd.config` migration notes remain in package CHANGELOGs, which are correct).

HTTPS enforcement will be flipped on once GitHub finishes provisioning the TLS cert for the domain.