### PR TITLE
fix(packages/core): kebab-case Zod schema keys silently fail

### DIFF
--- a/.changeset/kebab-case-schema-keys.md
+++ b/.changeset/kebab-case-schema-keys.md
@@ -1,0 +1,5 @@
+---
+'maltty': patch
+---
+
+Fix kebab-case Zod schema keys silently resolving to `undefined`. Previously the args parser stripped every argv key containing `-`, so an option defined as `'dry-run'` in a schema was dropped and `ctx.args['dry-run']` always fell back to its `.default()`. The parser now preserves both the kebab-case and camelCase variants yargs emits, so `ctx.args['dry-run']` and `ctx.args.dryRun` both resolve to the parsed value.

--- a/packages/maltty/src/runtime/args.test.ts
+++ b/packages/maltty/src/runtime/args.test.ts
@@ -181,8 +181,7 @@ describe('args with zod schema', () => {
 
     expect(handler).toHaveBeenCalledTimes(1)
     const ctx = handler.mock.calls[0]![0] as CommandContext
-    expect(ctx.args['dry-run']).toBeTruthy()
-    expect(ctx.args.dryRun).toBeTruthy()
+    expect(ctx.args).toMatchObject({ 'dry-run': true, dryRun: true })
   })
 
   it('applies the default for a kebab-case key when the flag is omitted', async () => {
@@ -206,7 +205,7 @@ describe('args with zod schema', () => {
 
     expect(handler).toHaveBeenCalledTimes(1)
     const ctx = handler.mock.calls[0]![0] as CommandContext
-    expect(ctx.args['dry-run']).toBeFalsy()
+    expect(ctx.args).toMatchObject({ 'dry-run': false })
   })
 })
 

--- a/packages/maltty/src/runtime/args.test.ts
+++ b/packages/maltty/src/runtime/args.test.ts
@@ -159,6 +159,55 @@ describe('args with zod schema', () => {
     const ctx = handler.mock.calls[0]![0] as CommandContext
     expect(ctx.args).toMatchObject({ verbose: true })
   })
+
+  it('exposes a kebab-case schema key on ctx.args (issue #177)', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      build: command({
+        description: 'Build the project',
+        options: z.object({
+          'dry-run': z.boolean().default(false).describe('Preview without writing'),
+        }),
+        handler,
+      }),
+    }
+
+    setArgv('build', '--dry-run')
+    await runTestCli({
+      commands,
+      name: 'test-cli',
+      version: '1.0.0',
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    const ctx = handler.mock.calls[0]![0] as CommandContext
+    expect(ctx.args['dry-run']).toBeTruthy()
+    expect(ctx.args.dryRun).toBeTruthy()
+  })
+
+  it('applies the default for a kebab-case key when the flag is omitted', async () => {
+    const handler = vi.fn()
+    const commands: CommandMap = {
+      build: command({
+        description: 'Build the project',
+        options: z.object({
+          'dry-run': z.boolean().default(false).describe('Preview without writing'),
+        }),
+        handler,
+      }),
+    }
+
+    setArgv('build')
+    await runTestCli({
+      commands,
+      name: 'test-cli',
+      version: '1.0.0',
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    const ctx = handler.mock.calls[0]![0] as CommandContext
+    expect(ctx.args['dry-run']).toBeFalsy()
+  })
 })
 
 describe('args with yargs native format', () => {

--- a/packages/maltty/src/runtime/args/parser.test.ts
+++ b/packages/maltty/src/runtime/args/parser.test.ts
@@ -29,7 +29,7 @@ describe('createArgsParser()', () => {
       expect(result).toStrictEqual({ file: 'index.ts' })
     })
 
-    it('should strip hyphenated keys (camelCase duplicates)', () => {
+    it('should keep both kebab and camelCase variants of a key', () => {
       const parser = createArgsParser({ options: undefined, positionals: undefined })
       const [error, result] = parser.parse({
         'dry-run': true,
@@ -38,10 +38,10 @@ describe('createArgsParser()', () => {
       })
 
       expect(error).toBeNull()
-      expect(result).toStrictEqual({ dryRun: true, output: 'dist' })
+      expect(result).toStrictEqual({ 'dry-run': true, dryRun: true, output: 'dist' })
     })
 
-    it('should strip all yargs-internal keys simultaneously', () => {
+    it('should strip only yargs-internal keys and keep kebab variants', () => {
       const parser = createArgsParser({ options: undefined, positionals: undefined })
       const [error, result] = parser.parse({
         $0: 'cli',
@@ -52,7 +52,7 @@ describe('createArgsParser()', () => {
       })
 
       expect(error).toBeNull()
-      expect(result).toStrictEqual({ dryRun: true, name: 'test' })
+      expect(result).toStrictEqual({ 'dry-run': true, dryRun: true, name: 'test' })
     })
 
     it('should return an empty object when all keys are internal', () => {
@@ -108,6 +108,34 @@ describe('createArgsParser()', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error!.message).toContain('Invalid arguments')
+    })
+
+    it('should resolve a kebab-case schema key from the kebab-case argv variant', () => {
+      const options = z.object({ 'dry-run': z.boolean().default(false) })
+      const parser = createArgsParser({ options, positionals: undefined })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+
+      expect(error).toBeNull()
+      expect(result).toMatchObject({ 'dry-run': true })
+    })
+
+    it('should not fall back to the default for a kebab-case schema key', () => {
+      const options = z.object({ 'dry-run': z.boolean().default(false) })
+      const parser = createArgsParser({ options, positionals: undefined })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+
+      expect(error).toBeNull()
+      expect(result!['dry-run']).toBeTruthy()
+    })
+
+    it('should expose both accessors for a kebab-case schema key (passthrough)', () => {
+      const options = z.object({ 'dry-run': z.boolean().default(false) })
+      const parser = createArgsParser({ options, positionals: undefined })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+
+      expect(error).toBeNull()
+      expect(result!['dry-run']).toBeTruthy()
+      expect(result!.dryRun).toBeTruthy()
     })
   })
 
@@ -169,6 +197,16 @@ describe('createArgsParser()', () => {
 
       expect(error).toBeNull()
       expect(result).toStrictEqual({ file: 'index.ts', verbose: true })
+    })
+
+    it('should resolve a kebab-case key and drop the camelCase variant in a merged schema', () => {
+      const options = z.object({ 'dry-run': z.boolean() })
+      const positionals = z.object({ file: z.string() })
+      const parser = createArgsParser({ options, positionals })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true, file: 'index.ts' })
+
+      expect(error).toBeNull()
+      expect(result).toStrictEqual({ 'dry-run': true, file: 'index.ts' })
     })
   })
 

--- a/packages/maltty/src/runtime/args/parser.test.ts
+++ b/packages/maltty/src/runtime/args/parser.test.ts
@@ -113,7 +113,7 @@ describe('createArgsParser()', () => {
     it('should resolve a kebab-case schema key from the kebab-case argv variant', () => {
       const options = z.object({ 'dry-run': z.boolean().default(false) })
       const parser = createArgsParser({ options, positionals: undefined })
-      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: false })
 
       expect(error).toBeNull()
       expect(result).toMatchObject({ 'dry-run': true })
@@ -122,20 +122,19 @@ describe('createArgsParser()', () => {
     it('should not fall back to the default for a kebab-case schema key', () => {
       const options = z.object({ 'dry-run': z.boolean().default(false) })
       const parser = createArgsParser({ options, positionals: undefined })
-      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: false })
 
       expect(error).toBeNull()
-      expect(result!['dry-run']).toBeTruthy()
+      expect(result).toMatchObject({ 'dry-run': true })
     })
 
     it('should expose both accessors for a kebab-case schema key (passthrough)', () => {
       const options = z.object({ 'dry-run': z.boolean().default(false) })
       const parser = createArgsParser({ options, positionals: undefined })
-      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: false })
 
       expect(error).toBeNull()
-      expect(result!['dry-run']).toBeTruthy()
-      expect(result!.dryRun).toBeTruthy()
+      expect(result).toMatchObject({ 'dry-run': true, dryRun: false })
     })
   })
 
@@ -203,7 +202,7 @@ describe('createArgsParser()', () => {
       const options = z.object({ 'dry-run': z.boolean() })
       const positionals = z.object({ file: z.string() })
       const parser = createArgsParser({ options, positionals })
-      const [error, result] = parser.parse({ 'dry-run': true, dryRun: true, file: 'index.ts' })
+      const [error, result] = parser.parse({ 'dry-run': true, dryRun: false, file: 'index.ts' })
 
       expect(error).toBeNull()
       expect(result).toStrictEqual({ 'dry-run': true, file: 'index.ts' })

--- a/packages/maltty/src/runtime/args/parser.ts
+++ b/packages/maltty/src/runtime/args/parser.ts
@@ -69,17 +69,20 @@ function buildMergedSchema(
 }
 
 /**
- * Strip yargs-internal keys (`_`, `$0`) and camelCase-duplicated hyphenated keys
- * from a parsed argv record, returning only user-defined arguments.
+ * Strip yargs-internal keys (`_`, `$0`) from a parsed argv record, returning
+ * only user-defined arguments.
+ *
+ * Both kebab-case (`dry-run`) and camelCase (`dryRun`) variants that yargs emits
+ * are preserved so a Zod schema keyed by either form validates against the
+ * matching key. Strict merged schemas drop whichever variant they don't declare;
+ * passthrough (and no-schema) results keep both, so both accessors resolve.
  *
  * @private
  * @param argv - Raw parsed argv from yargs.
  * @returns A cleaned record containing only user-defined arguments.
  */
 function cleanParsedArgs(argv: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(argv).filter(([key]) => key !== '_' && key !== '$0' && !key.includes('-'))
-  )
+  return Object.fromEntries(Object.entries(argv).filter(([key]) => key !== '_' && key !== '$0'))
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #177 — kebab-case Zod schema keys silently resolved to `undefined`.

`cleanParsedArgs` in `packages/maltty/src/runtime/args/parser.ts` stripped **every** argv key containing `-`. Yargs emits both `dry-run` and `dryRun` on `argv`; the filter dropped the kebab variant, so a schema keyed `'dry-run'` never matched a parsed key and validation fell back to `.default()`. Result: `ctx.args['dry-run']` was always `undefined`, and only the accidental camelCase `ctx.args.dryRun` worked.

## Fix

Stop stripping kebab keys — only strip the yargs-internal `_` and `$0`. Both variants yargs emits are preserved, so the accessor matching your schema key always resolves:

- **Strict merged schema** — Zod keeps whichever variant the schema declares, drops the other. `ctx.args['dry-run']` works.
- **Passthrough / no schema** — both variants survive, so `ctx.args['dry-run']` **and** `ctx.args.dryRun` resolve.

```diff
 function cleanParsedArgs(argv: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(argv).filter(([key]) => key !== '_' && key !== '$0' && !key.includes('-'))
-  )
+  return Object.fromEntries(Object.entries(argv).filter(([key]) => key !== '_' && key !== '$0'))
 }
```

## Tests

- **Unit** (`parser.test.ts`) — kebab schema key resolves from the kebab argv variant, no default fallback, both accessors present under passthrough, and merged-schema resolves the kebab key while dropping the unmatched camel variant. Updated the two prior tests that encoded the buggy stripping behavior.
- **Integration** (`args.test.ts`) — full CLI → handler flow: `test-cli build --dry-run` exposes `ctx.args['dry-run']` and `ctx.args.dryRun` as `true`; omitting the flag applies the `.default(false)`.

`pnpm check` and full `pnpm test` (1081 tests) pass.
