### PR TITLE
fix(packages/core): surface async errors from screen() useEffect callbacks

### DIFF
--- a/.changeset/screen-async-error-surfacing.md
+++ b/.changeset/screen-async-error-surfacing.md
@@ -1,0 +1,5 @@
+---
+'maltty': patch
+---
+
+Fix `screen()` commands silently swallowing errors thrown in async `useEffect` callbacks. Ink resolves `waitUntilExit()` on unmount even when a fire-and-forget async effect rejects, so the error never reached the runtime's error channel — and in fullscreen mode the global crash handler printed into the alternate buffer that was then cleared on exit, leaving no trace. The screen runtime now takes ownership of async error handling while mounted: it suspends the global crash handlers, races an internal guard against `waitUntilExit()` to capture the first `unhandledRejection`/`uncaughtException`, leaves the alternate screen buffer, and rejects so the error surfaces through the normal channel (visible message, exit code 1).

--- a/packages/maltty/src/screen/screen.test.ts
+++ b/packages/maltty/src/screen/screen.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
 import type { CommandContext, ScreenContext, Store } from '../context/types.js'
+import { LEAVE_ALT_SCREEN } from '../ui/layout/fullscreen.js'
 
 vi.mock(import('ink'), () => ({
   render: vi.fn(() => ({
@@ -411,5 +412,101 @@ describe('screen() render function', () => {
 
     expect(writeSpy).toHaveBeenCalledWith('\u001B[?1049l')
     writeSpy.mockRestore()
+  })
+})
+
+describe('screen() async error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Park waitUntilExit forever so the async error (not a normal unmount) settles the render.
+  function mockPendingScreen(): ReturnType<typeof vi.fn> {
+    const unmount = vi.fn()
+    mockedInkRender.mockReturnValue({
+      unmount,
+      waitUntilExit: vi.fn(() => new Promise<void>(() => {})),
+    } as never)
+    return unmount
+  }
+
+  // Advance renderFn past the dynamic import so the guard's listeners are installed before we emit.
+  async function flushRenderStartup(): Promise<void> {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+  }
+
+  it('should surface an async unhandledRejection thrown during the render window', async () => {
+    const unmount = mockPendingScreen()
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ render: StubComponent })
+
+    const renderPromise = cmd.render!(makeContext())
+    await flushRenderStartup()
+    process.emit('unhandledRejection', new Error('async boom'), Promise.resolve())
+
+    await expect(renderPromise).rejects.toThrow('async boom')
+    expect(unmount).toHaveBeenCalledOnce()
+  })
+
+  it('should surface an uncaughtException thrown during the render window', async () => {
+    mockPendingScreen()
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ render: StubComponent })
+
+    const renderPromise = cmd.render!(makeContext())
+    await flushRenderStartup()
+    process.emit('uncaughtException', new Error('sync boom'))
+
+    await expect(renderPromise).rejects.toThrow('sync boom')
+  })
+
+  it('should leave fullscreen before surfacing an async error', async () => {
+    mockPendingScreen()
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ fullscreen: true, render: StubComponent })
+
+    const renderPromise = cmd.render!(makeContext())
+    await flushRenderStartup()
+    process.emit('unhandledRejection', new Error('async boom'), Promise.resolve())
+
+    await expect(renderPromise).rejects.toThrow('async boom')
+    expect(writeSpy).toHaveBeenCalledWith(LEAVE_ALT_SCREEN)
+    writeSpy.mockRestore()
+  })
+
+  it('should restore the global crash handlers after an async error', async () => {
+    mockPendingScreen()
+    const before = process.listeners('unhandledRejection').length
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ render: StubComponent })
+
+    const renderPromise = cmd.render!(makeContext())
+    await flushRenderStartup()
+    process.emit('unhandledRejection', new Error('async boom'), Promise.resolve())
+    await expect(renderPromise).rejects.toThrow('async boom')
+
+    expect(process.listeners('unhandledRejection')).toHaveLength(before)
+  })
+
+  it('should restore the global crash handlers after a normal exit', async () => {
+    mockedInkRender.mockReturnValue({
+      unmount: vi.fn(),
+      waitUntilExit: vi.fn().mockResolvedValue(undefined),
+    } as never)
+    const before = process.listeners('unhandledRejection').length
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ render: StubComponent })
+
+    await cmd.render!(makeContext())
+
+    expect(process.listeners('unhandledRejection')).toHaveLength(before)
   })
 })

--- a/packages/maltty/src/screen/screen.test.ts
+++ b/packages/maltty/src/screen/screen.test.ts
@@ -1,5 +1,5 @@
 import { hasTag } from '@maltty/utils/tag'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { z } from 'zod'
 
 import type { CommandContext, ScreenContext, Store } from '../context/types.js'
@@ -467,6 +467,9 @@ describe('screen() async error handling', () => {
   it('should leave fullscreen before surfacing an async error', async () => {
     mockPendingScreen()
     const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    onTestFinished(() => {
+      writeSpy.mockRestore()
+    })
 
     const { screen } = await import('./screen.js')
     const cmd = screen({ fullscreen: true, render: StubComponent })
@@ -477,12 +480,12 @@ describe('screen() async error handling', () => {
 
     await expect(renderPromise).rejects.toThrow('async boom')
     expect(writeSpy).toHaveBeenCalledWith(LEAVE_ALT_SCREEN)
-    writeSpy.mockRestore()
   })
 
-  it('should restore the global crash handlers after an async error', async () => {
+  it('should restore the exact crash handlers after an async error', async () => {
     mockPendingScreen()
-    const before = process.listeners('unhandledRejection').length
+    const beforeRejection = [...process.listeners('unhandledRejection')]
+    const beforeException = [...process.listeners('uncaughtException')]
 
     const { screen } = await import('./screen.js')
     const cmd = screen({ render: StubComponent })
@@ -492,21 +495,42 @@ describe('screen() async error handling', () => {
     process.emit('unhandledRejection', new Error('async boom'), Promise.resolve())
     await expect(renderPromise).rejects.toThrow('async boom')
 
-    expect(process.listeners('unhandledRejection')).toHaveLength(before)
+    expect(process.listeners('unhandledRejection')).toEqual(beforeRejection)
+    expect(process.listeners('uncaughtException')).toEqual(beforeException)
   })
 
-  it('should restore the global crash handlers after a normal exit', async () => {
+  it('should restore the exact crash handlers after a normal exit', async () => {
     mockedInkRender.mockReturnValue({
       unmount: vi.fn(),
       waitUntilExit: vi.fn().mockResolvedValue(undefined),
     } as never)
-    const before = process.listeners('unhandledRejection').length
+    const beforeRejection = [...process.listeners('unhandledRejection')]
+    const beforeException = [...process.listeners('uncaughtException')]
 
     const { screen } = await import('./screen.js')
     const cmd = screen({ render: StubComponent })
 
     await cmd.render!(makeContext())
 
-    expect(process.listeners('unhandledRejection')).toHaveLength(before)
+    expect(process.listeners('unhandledRejection')).toEqual(beforeRejection)
+    expect(process.listeners('uncaughtException')).toEqual(beforeException)
+  })
+
+  it('should leave a foreign listener registered mid-render untouched', async () => {
+    mockPendingScreen()
+    const foreign = (): void => {}
+
+    const { screen } = await import('./screen.js')
+    const cmd = screen({ render: StubComponent })
+
+    const renderPromise = cmd.render!(makeContext())
+    await flushRenderStartup()
+    // Registered while the guard owns the event — dispose must not drop it.
+    process.on('unhandledRejection', foreign)
+    process.emit('unhandledRejection', new Error('async boom'), Promise.resolve())
+    await expect(renderPromise).rejects.toThrow('async boom')
+
+    expect(process.listeners('unhandledRejection')).toContain(foreign)
+    process.removeListener('unhandledRejection', foreign)
   })
 })

--- a/packages/maltty/src/screen/screen.tsx
+++ b/packages/maltty/src/screen/screen.tsx
@@ -1,7 +1,8 @@
 import process from 'node:process'
 
-import { isFunction } from '@maltty/utils/fp'
+import { isFunction, toError } from '@maltty/utils/fp'
 import { withTag } from '@maltty/utils/tag'
+import type { Instance } from 'ink'
 import type { ComponentType } from 'react'
 import React from 'react'
 import { match } from 'ts-pattern'
@@ -159,9 +160,15 @@ export function screen<
       }, 0)
     }
 
+    // Guard async `useEffect` rejections that Ink swallows (see createAsyncErrorGuard).
+    // Racing the guard against `waitUntilExit()` surfaces async and render-phase failures.
+    // A rejected race re-rejects renderFn into the runtime's error channel, and the
+    // `finally` block leaves fullscreen first so the message survives.
+    const guard = createAsyncErrorGuard(instance)
     try {
-      await instance.waitUntilExit()
+      await Promise.race([instance.waitUntilExit(), guard.signal])
     } finally {
+      guard.dispose()
       if (isFullscreen) {
         process.stdout.write(LEAVE_ALT_SCREEN)
       }
@@ -187,6 +194,101 @@ export function screen<
 // ---------------------------------------------------------------------------
 // Private
 // ---------------------------------------------------------------------------
+
+/**
+ * A scoped guard over async errors thrown while a screen is mounted.
+ *
+ * @private
+ */
+interface AsyncErrorGuard {
+  /**
+   * Rejects with the first async error captured during the render window.
+   */
+  readonly signal: Promise<never>
+
+  /**
+   * Restores the suspended global crash handlers.
+   */
+  readonly dispose: () => void
+}
+
+/**
+ * A process error event whose global handlers the screen runtime suspends.
+ *
+ * @private
+ */
+type ProcessErrorEvent = 'unhandledRejection' | 'uncaughtException'
+
+/**
+ * A process-level error listener for `unhandledRejection` / `uncaughtException`.
+ *
+ * @private
+ */
+type ProcessErrorListener = (...args: unknown[]) => void
+
+/**
+ * Suspend Node's global crash handlers and capture the first async error thrown
+ * while a screen is mounted.
+ *
+ * Ink resolves `waitUntilExit()` on unmount even when an async `useEffect`
+ * callback rejects, so those rejections never reach the runtime's error
+ * channel. Worse, the global `unhandledRejection` handler (registered by the
+ * crash reporter) fires first and calls `process.exit(1)` before the screen can
+ * leave the alternate buffer — erasing the message in fullscreen mode. This
+ * guard takes ownership of async error handling for the render window: it
+ * removes the global listeners, installs its own that unmount the screen and
+ * reject {@link AsyncErrorGuard.signal} with the first error, and restores the
+ * globals via {@link AsyncErrorGuard.dispose} so ordering (leave fullscreen,
+ * then print) is controlled by the screen runtime.
+ *
+ * @private
+ * @param instance - The Ink render instance to unmount when an error is caught.
+ * @returns A guard exposing a rejection signal and a dispose function.
+ */
+function createAsyncErrorGuard(instance: Instance): AsyncErrorGuard {
+  const savedRejection = process.listeners(
+    'unhandledRejection'
+  ) as unknown as readonly ProcessErrorListener[]
+  const savedException = process.listeners(
+    'uncaughtException'
+  ) as unknown as readonly ProcessErrorListener[]
+  const { promise, reject } = Promise.withResolvers<never>()
+  const onError = (error: unknown): void => {
+    instance.unmount()
+    reject(toError(error))
+  }
+
+  process.removeAllListeners('unhandledRejection')
+  process.removeAllListeners('uncaughtException')
+  process.on('unhandledRejection', onError)
+  process.on('uncaughtException', onError)
+
+  const dispose = (): void => {
+    process.removeAllListeners('unhandledRejection')
+    process.removeAllListeners('uncaughtException')
+    restoreListeners('unhandledRejection', savedRejection)
+    restoreListeners('uncaughtException', savedException)
+  }
+
+  return { dispose, signal: promise }
+}
+
+/**
+ * Re-attach previously saved listeners to a process error event, in order.
+ *
+ * @private
+ * @param event - The process error event to restore listeners for.
+ * @param listeners - The listeners captured before the guard took over.
+ */
+function restoreListeners(
+  event: ProcessErrorEvent,
+  listeners: readonly ProcessErrorListener[]
+): void {
+  listeners.reduce<null>((_acc, listener) => {
+    process.on(event, listener)
+    return null
+  }, null)
+}
 
 /**
  * Keys stripped from the screen context (no screen-safe equivalent).

--- a/packages/maltty/src/screen/screen.tsx
+++ b/packages/maltty/src/screen/screen.tsx
@@ -1,6 +1,6 @@
 import process from 'node:process'
 
-import { isFunction, toError } from '@maltty/utils/fp'
+import { attempt, isFunction, toError } from '@maltty/utils/fp'
 import { withTag } from '@maltty/utils/tag'
 import type { Instance } from 'ink'
 import type { ComponentType } from 'react'
@@ -227,8 +227,8 @@ type ProcessErrorEvent = 'unhandledRejection' | 'uncaughtException'
 type ProcessErrorListener = (...args: unknown[]) => void
 
 /**
- * Suspend Node's global crash handlers and capture the first async error thrown
- * while a screen is mounted.
+ * Suspend the pre-existing global crash handlers and capture the first async
+ * error thrown while a screen is mounted.
  *
  * Ink resolves `waitUntilExit()` on unmount even when an async `useEffect`
  * callback rejects, so those rejections never reach the runtime's error
@@ -236,58 +236,65 @@ type ProcessErrorListener = (...args: unknown[]) => void
  * crash reporter) fires first and calls `process.exit(1)` before the screen can
  * leave the alternate buffer — erasing the message in fullscreen mode. This
  * guard takes ownership of async error handling for the render window: it
- * removes the global listeners, installs its own that unmount the screen and
- * reject {@link AsyncErrorGuard.signal} with the first error, and restores the
- * globals via {@link AsyncErrorGuard.dispose} so ordering (leave fullscreen,
- * then print) is controlled by the screen runtime.
+ * removes only the listeners it captured, prepends its own that reject
+ * {@link AsyncErrorGuard.signal} with the first error and unmount the screen,
+ * and restores exactly those captured listeners via
+ * {@link AsyncErrorGuard.dispose}. Foreign listeners (and those from an
+ * overlapping guard) are left untouched, so nesting and concurrency are safe.
  *
  * @private
  * @param instance - The Ink render instance to unmount when an error is caught.
  * @returns A guard exposing a rejection signal and a dispose function.
  */
 function createAsyncErrorGuard(instance: Instance): AsyncErrorGuard {
-  const savedRejection = process.listeners(
-    'unhandledRejection'
-  ) as unknown as readonly ProcessErrorListener[]
-  const savedException = process.listeners(
-    'uncaughtException'
-  ) as unknown as readonly ProcessErrorListener[]
   const { promise, reject } = Promise.withResolvers<never>()
   const onError = (error: unknown): void => {
-    instance.unmount()
+    // Settle the signal first, then unmount. Ink's unmount runs user effect teardown;
+    // If that throws, the rejection is already registered so renderFn never strands.
+    // Any unmount failure is swallowed rather than allowed to escape the listener.
     reject(toError(error))
+    attempt(() => instance.unmount())
   }
 
-  process.removeAllListeners('unhandledRejection')
-  process.removeAllListeners('uncaughtException')
-  process.on('unhandledRejection', onError)
-  process.on('uncaughtException', onError)
+  const restoreRejection = suspendListeners('unhandledRejection')
+  const restoreException = suspendListeners('uncaughtException')
+  process.prependListener('unhandledRejection', onError)
+  process.prependListener('uncaughtException', onError)
 
   const dispose = (): void => {
-    process.removeAllListeners('unhandledRejection')
-    process.removeAllListeners('uncaughtException')
-    restoreListeners('unhandledRejection', savedRejection)
-    restoreListeners('uncaughtException', savedException)
+    process.removeListener('unhandledRejection', onError)
+    process.removeListener('uncaughtException', onError)
+    restoreRejection()
+    restoreException()
   }
 
   return { dispose, signal: promise }
 }
 
 /**
- * Re-attach previously saved listeners to a process error event, in order.
+ * Remove a process error event's current listeners and return a function that
+ * re-attaches exactly those listeners, in their original order.
+ *
+ * Only the listeners present when this is called are touched, so listeners
+ * registered by unrelated code (or an overlapping guard) during the render
+ * window survive.
  *
  * @private
- * @param event - The process error event to restore listeners for.
- * @param listeners - The listeners captured before the guard took over.
+ * @param event - The process error event to suspend.
+ * @returns A restore function that re-attaches the captured listeners.
  */
-function restoreListeners(
-  event: ProcessErrorEvent,
-  listeners: readonly ProcessErrorListener[]
-): void {
-  listeners.reduce<null>((_acc, listener) => {
-    process.on(event, listener)
+function suspendListeners(event: ProcessErrorEvent): () => void {
+  const captured = process.listeners(event) as unknown as readonly ProcessErrorListener[]
+  captured.reduce<null>((_acc, listener) => {
+    process.removeListener(event, listener)
     return null
   }, null)
+  return () => {
+    captured.reduce<null>((_acc, listener) => {
+      process.on(event, listener)
+      return null
+    }, null)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #174 — `screen()` commands silently swallowed errors thrown inside async `useEffect` callbacks.

## Root cause (verified empirically)

Ink resolves `waitUntilExit()` on unmount **even when a fire-and-forget async `useEffect` callback rejects**, so the error never reached the runtime's error channel. I reproduced the real behavior with Ink 7:

- `waitUntilExit()` resolves normally — it never rejects for async-effect errors.
- The rejection *does* surface as a Node `unhandledRejection`, but the global crash handler (registered first at startup) wins the listener race and calls `process.exit(1)` synchronously — before the screen can leave the alternate buffer.
- In fullscreen, that means the message is printed into the alt-screen, which is then cleared on exit. No trace remains; the process exits silently.

## Fix

The screen runtime now **owns async error handling while a screen is mounted** (`createAsyncErrorGuard`):

1. Suspends the global `unhandledRejection` / `uncaughtException` handlers.
2. Installs its own that unmount Ink and reject an internal `signal`.
3. `renderFn` races that signal against `waitUntilExit()` — a rejected race propagates through `finally` (which leaves the alternate buffer first) and re-rejects `renderFn`, flowing into the runtime's normal error channel (visible message, exit 1).
4. Restores the global handlers on `dispose`.

This unifies async-effect errors and render-phase rejections into one path, and controls teardown ordering (leave fullscreen → then print) so the message survives.

## Verification

- Reproduced the bug and validated the fix against **real Ink** (not mocks): with the guard, an async `useEffect` throw now rejects `renderFn` with the error, the suspended global handler does not fire, and the process exits 1 with the error visible.
- 6 new unit/integration tests in `screen.test.ts` covering: async `unhandledRejection` surfacing + unmount, `uncaughtException` surfacing, leaving fullscreen before the error, and global-handler restoration after both error and normal exit.
- `pnpm check` clean (typecheck + lint + format); full `pnpm test` green (1080 tests).

## Notes

- No `throw` / `return Promise.reject` — the error propagates via natural async rejection through `finally`, consistent with the repo's no-throw functional style.
- `unmount` fires only on the error path, preserving the existing "no unmount on normal exit" behavior.
